### PR TITLE
Remove user id from models

### DIFF
--- a/app/controllers/arch_objects_controller.rb
+++ b/app/controllers/arch_objects_controller.rb
@@ -36,13 +36,6 @@ class ArchObjectsController < ApplicationController
   # POST /arch_objects.json
   def create
     @arch_object = ArchObject.new(arch_object_params)
-    # add user_id of current user
-    @arch_object.samples.each { |sample| sample.measurements.each { |measurement| measurement.user_id = current_user.id if current_user } }
-    @arch_object.site_phase.user_id = current_user.id if current_user
-    @arch_object.site_phase.ecochronological_units.each { |ecochronological_unit| ecochronological_unit.user_id = current_user.id if current_user }
-    @arch_object.site_phase.periods.each { |period| period.user_id = current_user.id if current_user }
-    @arch_object.site_phase.typochronological_units.each { |typochronological_unit| typochronological_unit.user_id = current_user.id if current_user }
-    @arch_object.site_phase.site.fell_phases.each { |fell_phase| fell_phase.user_id = current_user.id if current_user }
 
     respond_to do |format|
       if @arch_object.save
@@ -194,7 +187,6 @@ class ArchObjectsController < ApplicationController
             :labnr,
             :sample_id,
             :lab_id,
-            :user_id,
             :c14_measurement_id,
             :_destroy,
             :c14_measurement_attributes => [

--- a/app/controllers/ecochronological_units_controller.rb
+++ b/app/controllers/ecochronological_units_controller.rb
@@ -27,7 +27,6 @@ class EcochronologicalUnitsController < ApplicationController
   # POST /ecochronological_units.json
   def create
     @ecochronological_unit = EcochronologicalUnit.new(ecochronological_unit_params)
-    @ecochronological_unit.user_id = current_user.id if current_user
 
     respond_to do |format|
       if @ecochronological_unit.save

--- a/app/controllers/fell_phases_controller.rb
+++ b/app/controllers/fell_phases_controller.rb
@@ -28,7 +28,6 @@ class FellPhasesController < ApplicationController
   # POST /fell_phases.json
   def create
     @fell_phase = FellPhase.new(fell_phase_params)
-    @fell_phase.user_id = current_user.id if current_user
 
     respond_to do |format|
       if @fell_phase.save

--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -30,7 +30,6 @@ class MeasurementsController < ApplicationController
   # POST /measurements.json
   def create
     @measurement = Measurement.new(measurement_params)
-    @measurement.user_id = current_user.id if current_user
 
     respond_to do |format|
       if @measurement.save
@@ -81,7 +80,6 @@ class MeasurementsController < ApplicationController
         :_destroy,
         :sample_id,
         :lab_id,
-        :user_id,
         :c14_measurement_id,
         :c14_measurement_attributes => [
           :id,

--- a/app/controllers/periods_controller.rb
+++ b/app/controllers/periods_controller.rb
@@ -27,7 +27,6 @@ class PeriodsController < ApplicationController
   # POST /periods.json
   def create
     @period = Period.new(period_params)
-    @period.user_id = current_user.id if current_user
 
     respond_to do |format|
       if @period.save

--- a/app/controllers/site_phases_controller.rb
+++ b/app/controllers/site_phases_controller.rb
@@ -32,7 +32,6 @@ class SitePhasesController < ApplicationController
   # POST /site_phases.json
   def create
     @site_phase = SitePhase.new(site_phase_params)
-    @site_phase.user_id = current_user.id if current_user
 
     respond_to do |format|
       if @site_phase.save

--- a/app/controllers/typochronological_units_controller.rb
+++ b/app/controllers/typochronological_units_controller.rb
@@ -27,7 +27,6 @@ class TypochronologicalUnitsController < ApplicationController
   # POST /typochronological_units.json
   def create
     @typochronological_unit = TypochronologicalUnit.new(typochronological_unit_params)
-    @typochronological_unit.user_id = current_user.id if current_user
 
     respond_to do |format|
       if @typochronological_unit.save

--- a/app/models/ecochronological_unit.rb
+++ b/app/models/ecochronological_unit.rb
@@ -3,5 +3,4 @@ class EcochronologicalUnit < ApplicationRecord
   has_and_belongs_to_many :site_phases
   belongs_to :parent, class_name: "EcochronologicalUnit", optional: true
   has_many :children, class_name: "EcochronologicalUnit", foreign_key: "parent_id"
-  belongs_to :user
 end

--- a/app/models/fell_phase.rb
+++ b/app/models/fell_phase.rb
@@ -2,8 +2,6 @@ class FellPhase < ApplicationRecord
 
   belongs_to :site
   
-  belongs_to :user
-
   has_and_belongs_to_many :references
   accepts_nested_attributes_for :references, reject_if: :all_blank
   validates_associated :references

--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -14,8 +14,6 @@ class Measurement < ApplicationRecord
   accepts_nested_attributes_for :references, reject_if: :all_blank
   validates_associated :references
 
-  belongs_to :user
-
   def self.to_csv
     CSV.generate :force_quotes=>true do |csv|
       csv << [

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -3,5 +3,4 @@ class Period < ApplicationRecord
   has_and_belongs_to_many :site_phases
   belongs_to :parent, class_name: "Period", optional: true
   has_many :children, class_name: "Period", foreign_key: "parent_id"
-  belongs_to :user
 end

--- a/app/models/site_phase.rb
+++ b/app/models/site_phase.rb
@@ -24,5 +24,4 @@ class SitePhase < ApplicationRecord
   accepts_nested_attributes_for :site_type, reject_if: :all_blank, allow_destroy: true
   validates_associated :site_type
 
-  belongs_to :user
 end

--- a/app/models/typochronological_unit.rb
+++ b/app/models/typochronological_unit.rb
@@ -3,5 +3,4 @@ class TypochronologicalUnit < ApplicationRecord
   has_and_belongs_to_many :site_phases
   belongs_to :parent, class_name: "TypochronologicalUnit", optional: true
   has_many :children, class_name: "TypochronologicalUnit", foreign_key: "parent_id"
-  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,5 +8,4 @@ class User < ApplicationRecord
   validates :passphrase, format: { with: Regexp.new(ENV["REGISTRATION_PASSPHRASE"]) , message: "is wrong. Please contact ... to get a correct passphrase to register." }
 
   has_many :measurements, inverse_of: :user
-  has_many :fell_phases, inverse_of: :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,5 +11,4 @@ class User < ApplicationRecord
   has_many :fell_phases, inverse_of: :user
   has_many :site_phases, inverse_of: :user
   has_many :ecochronological_units, inverse_of: :user
-  has_many :typochronological_units, inverse_of: :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,5 +10,4 @@ class User < ApplicationRecord
   has_many :measurements, inverse_of: :user
   has_many :fell_phases, inverse_of: :user
   has_many :site_phases, inverse_of: :user
-  has_many :ecochronological_units, inverse_of: :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,5 +9,4 @@ class User < ApplicationRecord
 
   has_many :measurements, inverse_of: :user
   has_many :fell_phases, inverse_of: :user
-  has_many :site_phases, inverse_of: :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,4 @@ class User < ApplicationRecord
   has_many :site_phases, inverse_of: :user
   has_many :ecochronological_units, inverse_of: :user
   has_many :typochronological_units, inverse_of: :user
-  has_many :periods, inverse_of: :user
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,5 +7,4 @@ class User < ApplicationRecord
   attr_accessor :passphrase
   validates :passphrase, format: { with: Regexp.new(ENV["REGISTRATION_PASSPHRASE"]) , message: "is wrong. Please contact ... to get a correct passphrase to register." }
 
-  has_many :measurements, inverse_of: :user
 end

--- a/db/migrate/20210801122336_remove_user_id_from_period.rb
+++ b/db/migrate/20210801122336_remove_user_id_from_period.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromPeriod < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :periods, :user_id, :bigint
+  end
+end

--- a/db/migrate/20210801122832_remove_user_id_from_typochronological_unit.rb
+++ b/db/migrate/20210801122832_remove_user_id_from_typochronological_unit.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromTypochronologicalUnit < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :typochronological_units, :user_id, :bigint
+  end
+end

--- a/db/migrate/20210801123120_remove_user_id_from_ecochronological_unit.rb
+++ b/db/migrate/20210801123120_remove_user_id_from_ecochronological_unit.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromEcochronologicalUnit < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :ecochronological_units, :user_id, :bigint
+  end
+end

--- a/db/migrate/20210801123336_remove_user_id_from_site_phase.rb
+++ b/db/migrate/20210801123336_remove_user_id_from_site_phase.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromSitePhase < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :site_phases, :user_id, :bigint
+  end
+end

--- a/db/migrate/20210801123602_remove_user_id_from_fell_phase.rb
+++ b/db/migrate/20210801123602_remove_user_id_from_fell_phase.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromFellPhase < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :fell_phases, :user_id, :bigint
+  end
+end

--- a/db/migrate/20210801124700_remove_user_id_from_measurement.rb
+++ b/db/migrate/20210801124700_remove_user_id_from_measurement.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromMeasurement < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :measurements, :user_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_25_155420) do
+ActiveRecord::Schema.define(version: 2021_08_01_122832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -137,8 +137,6 @@ ActiveRecord::Schema.define(version: 2020_06_25_155420) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "parent_id"
-    t.bigint "user_id"
-    t.index ["user_id"], name: "index_periods_on_user_id"
   end
 
   create_table "periods_site_phases", id: false, force: :cascade do |t|
@@ -230,8 +228,6 @@ ActiveRecord::Schema.define(version: 2020_06_25_155420) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "parent_id"
-    t.bigint "user_id"
-    t.index ["user_id"], name: "index_typochronological_units_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -254,7 +250,5 @@ ActiveRecord::Schema.define(version: 2020_06_25_155420) do
   add_foreign_key "measurements", "labs"
   add_foreign_key "measurements", "samples"
   add_foreign_key "measurements", "users"
-  add_foreign_key "periods", "users"
   add_foreign_key "site_phases", "users"
-  add_foreign_key "typochronological_units", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_01_123602) do
+ActiveRecord::Schema.define(version: 2021_08_01_124700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -102,11 +102,9 @@ ActiveRecord::Schema.define(version: 2021_08_01_123602) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "c14_measurement_id"
-    t.bigint "user_id"
     t.index ["c14_measurement_id"], name: "index_measurements_on_c14_measurement_id"
     t.index ["lab_id"], name: "index_measurements_on_lab_id"
     t.index ["sample_id"], name: "index_measurements_on_sample_id"
-    t.index ["user_id"], name: "index_measurements_on_user_id"
   end
 
   create_table "measurements_references", id: false, force: :cascade do |t|
@@ -241,5 +239,4 @@ ActiveRecord::Schema.define(version: 2021_08_01_123602) do
   add_foreign_key "measurements", "c14_measurements"
   add_foreign_key "measurements", "labs"
   add_foreign_key "measurements", "samples"
-  add_foreign_key "measurements", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_01_123120) do
+ActiveRecord::Schema.define(version: 2021_08_01_123336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -179,8 +179,6 @@ ActiveRecord::Schema.define(version: 2021_08_01_123120) do
     t.datetime "updated_at", null: false
     t.integer "site_id"
     t.integer "site_type_id"
-    t.bigint "user_id"
-    t.index ["user_id"], name: "index_site_phases_on_user_id"
   end
 
   create_table "site_phases_typochronological_units", id: false, force: :cascade do |t|
@@ -247,5 +245,4 @@ ActiveRecord::Schema.define(version: 2021_08_01_123120) do
   add_foreign_key "measurements", "labs"
   add_foreign_key "measurements", "samples"
   add_foreign_key "measurements", "users"
-  add_foreign_key "site_phases", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_01_122832) do
+ActiveRecord::Schema.define(version: 2021_08_01_123120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,8 +51,6 @@ ActiveRecord::Schema.define(version: 2021_08_01_122832) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "parent_id"
-    t.bigint "user_id"
-    t.index ["user_id"], name: "index_ecochronological_units_on_user_id"
   end
 
   create_table "ecochronological_units_site_phases", id: false, force: :cascade do |t|
@@ -244,7 +242,6 @@ ActiveRecord::Schema.define(version: 2021_08_01_122832) do
   end
 
   add_foreign_key "c14_measurements", "source_databases"
-  add_foreign_key "ecochronological_units", "users"
   add_foreign_key "fell_phases", "users"
   add_foreign_key "measurements", "c14_measurements"
   add_foreign_key "measurements", "labs"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_01_123336) do
+ActiveRecord::Schema.define(version: 2021_08_01_123602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,9 +73,7 @@ ActiveRecord::Schema.define(version: 2021_08_01_123336) do
     t.integer "site_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
     t.index ["site_id"], name: "index_fell_phases_on_site_id"
-    t.index ["user_id"], name: "index_fell_phases_on_user_id"
   end
 
   create_table "fell_phases_references", id: false, force: :cascade do |t|
@@ -240,7 +238,6 @@ ActiveRecord::Schema.define(version: 2021_08_01_123336) do
   end
 
   add_foreign_key "c14_measurements", "source_databases"
-  add_foreign_key "fell_phases", "users"
   add_foreign_key "measurements", "c14_measurements"
   add_foreign_key "measurements", "labs"
   add_foreign_key "measurements", "samples"


### PR DESCRIPTION
Adding user_id to certain models was an initial idea to provide a user scope for regulating permissions. For the more advanced permission system that should be implemented finally and that was described in the proposal this is not zielführend, and would lead to problems for example when a user is deleted. Therefore, this is removed with this pull request and solves #75.