### PR TITLE
replace length by count

### DIFF
--- a/app/views/data/_filter_status.html.erb
+++ b/app/views/data/_filter_status.html.erb
@@ -1,8 +1,8 @@
 <% if @data.filters.any? %>
   <span class="<%= @data.xrons.any? ? "text-success" : "text-danger" %>">
-    Showing <%= @data.xrons.length %> of <%= @data.everything.length %> records
+    Showing <%= @data.xrons.count %> of <%= @data.everything.count %> records
     (<%= link_to "clear filters", :data %>)
   </span>
 <% else %>
-  <span class="text-dark">Showing <%= @data.everything.length %> records</span>
+  <span class="text-dark">Showing <%= @data.everything.count %> records</span>
 <% end %>


### PR DESCRIPTION
Using length causes an action on the array, which is significantly slower than a db query. This fixes the first delay in loading the browse-view. Already monkey-patched in production on the server.