### PR TITLE
Basic Postgres search API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,9 @@ end
 # pagination
 gem "pagy"
 
+# search
+gem "pg_search"
+
 # forms
 gem "bootstrap_form", "~> 5.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,9 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pg (1.3.5)
+    pg_search (2.3.6)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     popper_js (2.9.3)
     public_suffix (4.0.7)
     puma (5.6.4)
@@ -454,6 +457,7 @@ DEPENDENCIES
   pagy
   paper_trail
   pg
+  pg_search
   puma (< 6)
   rabl
   rails (~> 6.1.6)

--- a/app/controllers/c14s_controller.rb
+++ b/app/controllers/c14s_controller.rb
@@ -9,7 +9,15 @@ class C14sController < ApplicationController
   # GET /c14s
   # GET /c14s.json
   def index
-    @pagy, @c14s = pagy(C14.all.order(:lab_identifier))
+    @c14s = C14.includes(
+      {sample: [
+        :material,
+        :taxon,
+        :context
+      ]},
+      :references
+    )
+    @pagy, @c14s = pagy(@c14s)
   end
 
   # GET /c14s/search

--- a/app/controllers/c14s_controller.rb
+++ b/app/controllers/c14s_controller.rb
@@ -12,6 +12,22 @@ class C14sController < ApplicationController
     @pagy, @c14s = pagy(C14.all.order(:lab_identifier))
   end
 
+  # GET /c14s/search
+  # GET /c14s/search.json
+  def search
+    @c14s = C14.search(params[:q])
+
+    respond_to do |format|
+      format.html { 
+        @pagy, @c14s = pagy(@c14s)
+        render :index
+      }
+      format.json  {
+        render :index
+      }
+    end
+  end
+
   # GET /c14s/1
   # GET /c14s/1.json
   def show

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -9,6 +9,17 @@ class MaterialsController < ApplicationController
     @materials = Material.all
   end
 
+  # GET /materials/search.json
+  def search
+    @materials = Material.search(params[:q])
+
+    respond_to do |format|
+      format.json  {
+        render :index
+      }
+    end
+  end
+
   # GET /materials/1
   # GET /materials/1.json
   def show

--- a/app/controllers/site_types_controller.rb
+++ b/app/controllers/site_types_controller.rb
@@ -9,6 +9,17 @@ class SiteTypesController < ApplicationController
     @site_types = SiteType.all
   end
 
+  # GET /site_types/search.json
+  def search
+    @site_types = SiteType.search(params[:q])
+
+    respond_to do |format|
+      format.json  {
+        render :index
+      }
+    end
+  end
+
   # GET /site_types/1
   # GET /site_types/1.json
   def show

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -18,8 +18,23 @@ class SitesController < ApplicationController
         @pagy, @sites = pagy(Site.all.order(:name))
         render :index
       }
-    #  format.json { render json: DataDatatable.new(params) }
       format.json
+    end
+  end
+
+  # GET /sites/search
+  # GET /sites/search.json
+  def search
+    @sites = Site.search(params[:q])
+
+    respond_to do |format|
+      format.html { 
+        @pagy, @sites = pagy(@sites.order(:name))
+        render :index
+      }
+      format.json  {
+        render :index
+      }
     end
   end
 
@@ -90,6 +105,7 @@ class SitesController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def site_params
       params.fetch(:site, {}).permit(
+        :q,
         :id,
         :name,
         :lat,

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -9,6 +9,17 @@ class TaxonsController < ApplicationController
     @taxon = Taxon.all
   end
 
+  # GET /taxons/search.json
+  def search
+    @taxons = Taxon.search(params[:q])
+
+    respond_to do |format|
+      format.json  {
+        render :index
+      }
+    end
+  end
+
   # GET /taxon/1
   # GET /taxon/1.json
   def show

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,6 +9,7 @@ class Ability
     # permissions for every user, even if not logged in
     can :read, :all
     cannot :read, [UserProfile]
+    can :search, :all
     can :calibrate, :all
     can :calibrate_multi, :all
     can :calibrate_sum, :all

--- a/app/models/c14.rb
+++ b/app/models/c14.rb
@@ -1,6 +1,11 @@
 class C14 < ApplicationRecord
   include DataHelper
 
+  include PgSearch::Model
+  pg_search_scope :search, 
+    against: :lab_identifier, 
+    using: { tsearch: { prefix: true } } # match partial words
+
   has_paper_trail
 
   validates :bp, :std, presence: true

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -1,6 +1,11 @@
 class Material < ApplicationRecord
   default_scope { order(name: :asc) }
 
+  include PgSearch::Model
+  pg_search_scope :search, 
+    against: :name, 
+    using: { tsearch: { prefix: true } } # match partial words
+
   has_many :samples, inverse_of: :material
   validates :name, presence: true
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,6 +1,11 @@
 class Site < ApplicationRecord
   include DataHelper
 
+  include PgSearch::Model
+  pg_search_scope :search, 
+    against: :name, 
+    using: { tsearch: { prefix: true } } # match partial words
+
   has_paper_trail
   
   validates :name, presence: true

--- a/app/models/site_type.rb
+++ b/app/models/site_type.rb
@@ -1,6 +1,11 @@
 class SiteType < ApplicationRecord
   default_scope { order(name: :asc) }
 
+  include PgSearch::Model
+  pg_search_scope :search,
+    against: :name,
+    using: { tsearch: { prefix: true } } # match partial words
+
   validates :name, presence: true
   has_many :sites, inverse_of: :site_type
 end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -1,5 +1,11 @@
 class Taxon < ApplicationRecord
   default_scope { order(name: :asc) }
+
+  include PgSearch::Model
+  pg_search_scope :search, 
+    against: :name, 
+    using: { tsearch: { prefix: true } } # match partial words
+
   validates :name, presence: true
 
   has_many :samples

--- a/app/views/c14s/_c14.json.jbuilder
+++ b/app/views/c14s/_c14.json.jbuilder
@@ -1,13 +1,26 @@
-json.extract! measurement, :id, :labnr, :sample_id, :lab_id, :created_at, :updated_at
+json.extract! c14, 
+  :id, 
+  :lab_identifier, 
+  :c14_lab_id,
+  :sample_id,
+  :method, 
+  :bp, 
+  :std, 
+  :delta_c13, 
+  :delta_c13_std, 
+  :created_at, 
+  :updated_at
 
-json.lab measurement.lab, partial: 'labs/lab', as: :lab
-
-json.c14_measurement measurement.c14_measurement, partial: 'c14_measurements/c14_measurement', as: :c14_measurement
-
-json.references measurement.references, partial: 'references/reference', as: :reference
-
-json.sample do
-  json.partial! "/samples/sample", sample: measurement.sample
-end
-
-json.url measurement_url(measurement, format: :json)
+#json.extract! measurement, :id, :labnr, :sample_id, :lab_id, :created_at, :updated_at
+#
+#json.lab measurement.lab, partial: 'labs/lab', as: :lab
+#
+#json.c14_measurement measurement.c14_measurement, partial: 'c14_measurements/c14_measurement', as: :c14_measurement
+#
+#json.references measurement.references, partial: 'references/reference', as: :reference
+#
+#json.sample do
+#  json.partial! "/samples/sample", sample: measurement.sample
+#end
+#
+#json.url measurement_url(measurement, format: :json)

--- a/app/views/c14s/index.json.jbuilder
+++ b/app/views/c14s/index.json.jbuilder
@@ -1,10 +1,1 @@
-json.set! :data do
-  json.array! @c14_measurements do |c14_measurement|
-    json.partial! 'c14_measurements/c14_measurement', c14_measurement: c14_measurement
-    json.url  "
-              #{link_to 'Show', c14_measurement }
-              #{link_to 'Edit', edit_c14_measurement_path(c14_measurement)}
-              #{link_to 'Destroy', c14_measurement, method: :delete, data: { confirm: 'Are you sure?' }}
-              "
-  end
-end
+json.array! @c14s, partial: "c14s/c14", as: :c14

--- a/app/views/data/_filter_fields.html.erb
+++ b/app/views/data/_filter_fields.html.erb
@@ -12,7 +12,7 @@
     multiple: true,
     data: { 
       controller: "tom-select",
-      "tom-select-route-value": "sites",
+      "tom-select-route-value": "sites/search",
       "tom-select-value-value": "name",
       "tom-select-label-value": "name",
       "tom-select-search-value": "name"
@@ -39,7 +39,7 @@
     multiple: true,
     data: {
       controller: "tom-select",
-      "tom-select-route-value": "site_types",
+      "tom-select-route-value": "site_types/search",
       "tom-select-value-value": "name",
       "tom-select-label-value": "name",
       "tom-select-search-value": "name"
@@ -53,7 +53,7 @@
     multiple: true,
     data: {
       controller: "tom-select",
-      "tom-select-route-value": "materials",
+      "tom-select-route-value": "materials/search",
       "tom-select-value-value": "name",
       "tom-select-label-value": "name",
       "tom-select-search-value": "name"
@@ -67,7 +67,7 @@
     multiple: true,
     data: {
       controller: "tom-select",
-      "tom-select-route-value": "taxons",
+      "tom-select-route-value": "taxons/search",
       "tom-select-value-value": "name",
       "tom-select-label-value": "name",
       "tom-select-search-value": "name"
@@ -96,7 +96,7 @@
     multiple: true,
     data: {
       controller: "tom-select",
-      "tom-select-route-value": "c14s",
+      "tom-select-route-value": "c14s/search",
       "tom-select-value-value": "lab_identifier",
       "tom-select-label-value": "lab_identifier",
       "tom-select-search-value": "lab_identifier"

--- a/app/views/taxons/_species.json.jbuilder
+++ b/app/views/taxons/_species.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! species, :id, :name, :created_at, :updated_at
-json.url species_url(species, format: :json)

--- a/app/views/taxons/_taxon.json.jbuilder
+++ b/app/views/taxons/_taxon.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! taxon, :id, :name, :created_at, :updated_at
+json.url taxon_url(taxon, format: :json)

--- a/app/views/taxons/index.json.jbuilder
+++ b/app/views/taxons/index.json.jbuilder
@@ -1,10 +1,1 @@
-json.set! :data do
-  json.array! @species do |species|
-    json.partial! 'species/species', species: species
-    json.url  "
-              #{link_to 'Show', species }
-              #{link_to 'Edit', edit_species_path(species)}
-              #{link_to 'Destroy', species, method: :delete, data: { confirm: 'Are you sure?' }}
-              "
-  end
-end
+json.array! @taxons, partial: "taxons/taxon", as: :taxon

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   config.after_initialize do
     Bullet.enable        = true
-    Bullet.alert         = true
+    Bullet.alert         = false
     Bullet.bullet_logger = true
     Bullet.console       = true
     Bullet.rails_logger  = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
 
   # Ordinary resources
   resources :c14s do
+    get 'search', on: :collection
     member do
       get 'calibrate'
       get 'calibrate_multi'
@@ -22,14 +23,22 @@ Rails.application.routes.draw do
   end
   resources :c14_labs
   resources :contexts
-  resources :materials
+  resources :materials do
+    get 'search', on: :collection
+  end
   resources :measurement_states
   resources :references
   resources :samples
-  resources :sites
-  resources :site_types
+  resources :sites do
+    get 'search', on: :collection
+  end
+  resources :site_types do
+    get 'search', on: :collection
+  end
   resources :source_databases
-  resources :taxons
+  resources :taxons do
+    get 'search', on: :collection
+  end
   resources :typos
 
   # User management


### PR DESCRIPTION
This PR implements a basic search API for sites, site types, materials, taxons, and c14s using [pg_search](https://github.com/Casecommons/pg_search). Endpoints (JSON and, where applicable, HTML) are at e.g. https://xronos.ch/sites/search?q=<query>

Switching to this endpoint for autocomplete in the data browser fixes #141. It could also be a good starting point for app-wide search functionality.

It also fixes an N+1 query on the c14 index and disables bullet popup alerts in development (there are still console messages and a notification in the bottom-left of the screen).