### PR TITLE
Bug squashing

### DIFF
--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -1,4 +1,6 @@
 class ReferencesController < ApplicationController
+  include Pagy::Backend
+
   load_and_authorize_resource
 
   before_action :set_reference, only: [:show, :edit, :update, :destroy]
@@ -7,6 +9,7 @@ class ReferencesController < ApplicationController
   # GET /references.json
   def index
     @references = Reference.all
+    @pagy, @references = pagy(@references)
   end
 
   # GET /references/1

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -20,7 +20,7 @@ class ReferencesController < ApplicationController
   def show
     @reference = Reference.find(params[:id])
     @sites = @reference.sites.distinct
-    @c14s = @reference.c14s.includes([:references, sample: [:material, :taxon, :context]])
+    @c14s = @reference.c14s.includes([:references, sample: [:material, :taxon, context: [:site] ]])
     @typos = @reference.typos.includes([:references, sample: [ context: [:site] ]])
   end
 

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -18,6 +18,10 @@ class ReferencesController < ApplicationController
   # GET /references/1
   # GET /references/1.json
   def show
+    @reference = Reference.find(params[:id])
+    @sites = @reference.sites.distinct
+    @c14s = @reference.c14s.includes([:references, sample: [:material, :taxon, :context]])
+    @typos = @reference.typos.includes([sample: [ context: [:site] ]])
   end
 
   # GET /references/new

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -21,7 +21,7 @@ class ReferencesController < ApplicationController
     @reference = Reference.find(params[:id])
     @sites = @reference.sites.distinct
     @c14s = @reference.c14s.includes([:references, sample: [:material, :taxon, :context]])
-    @typos = @reference.typos.includes([sample: [ context: [:site] ]])
+    @typos = @reference.typos.includes([:references, sample: [ context: [:site] ]])
   end
 
   # GET /references/new

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -8,7 +8,10 @@ class ReferencesController < ApplicationController
   # GET /references
   # GET /references.json
   def index
-    @references = Reference.all
+    @references = Reference
+      .left_joins(:citations)
+      .select('"references".*, COUNT(citations.id) AS citations_count')
+      .group(:id)
     @pagy, @references = pagy(@references)
   end
 

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -43,7 +43,7 @@ class SitesController < ApplicationController
   def show
     @site = Site.find(params[:id])
     @c14s = @site.c14s.includes([:references, sample: [ :material, :taxon, :context ]])
-    @typos = @site.typos
+    @typos = @site.typos.includes([:references])
   end
 
   # GET /sites/new

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -41,7 +41,9 @@ class SitesController < ApplicationController
   # GET /sites/1
   # GET /sites/1.json
   def show
-    gon.selected_sites = [{id: @site.id, name: @site.name, lat: @site.lat, lng: @site.lng}].to_json
+    @site = Site.find(params[:id])
+    @c14s = @site.c14s.includes([:references, sample: [ :material, :taxon, :context ]])
+    @typos = @site.typos
   end
 
   # GET /sites/new

--- a/app/controllers/source_databases_controller.rb
+++ b/app/controllers/source_databases_controller.rb
@@ -6,7 +6,10 @@ class SourceDatabasesController < ApplicationController
   # GET /source_databases
   # GET /source_databases.json
   def index
-    @source_databases = SourceDatabase.all
+    @source_databases = SourceDatabase
+      .left_joins(:c14s)
+      .select("source_databases.*, COUNT(c14s.id) AS c14s_count")
+      .group(:id)
   end
 
   # GET /source_databases/1

--- a/app/controllers/typos_controller.rb
+++ b/app/controllers/typos_controller.rb
@@ -8,7 +8,7 @@ class TyposController < ApplicationController
   # GET /typos
   # GET /typos.json
   def index
-    @typos = Typo.all.includes([sample: [ context: [ :site ] ] ])
+    @typos = Typo.all.includes([:references, sample: [ context: [ :site ] ] ])
     @pagy, @typos = pagy(@typos)
   end
 

--- a/app/controllers/typos_controller.rb
+++ b/app/controllers/typos_controller.rb
@@ -8,7 +8,8 @@ class TyposController < ApplicationController
   # GET /typos
   # GET /typos.json
   def index
-    @pagy, @typos = pagy(Typo.all)
+    @typos = Typo.all.includes([sample: [ context: [ :site ] ] ])
+    @pagy, @typos = pagy(@typos)
   end
 
   # GET /typos/1

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -6,6 +6,10 @@ class Reference < ApplicationRecord
   validates :short_ref, presence: true
   has_many :citations, dependent: :destroy
 
+  has_many :sites, :through => :citations, :source => :citing, :source_type => 'Site'
+  has_many :c14s, :through => :citations, :source => :citing, :source_type => 'C14'
+  has_many :typos, :through => :citations, :source => :citing, :source_type => 'Typo'
+
   def anchor
     if short_ref.blank?
       return ""

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -6,6 +6,14 @@ class Reference < ApplicationRecord
   validates :short_ref, presence: true
   has_many :citations, dependent: :destroy
 
+  def anchor
+    if short_ref.blank?
+      return ""
+    end
+
+    "ref-" + CGI.escape(short_ref)
+  end
+
   def format_bibtex
     parse.to_s
   end

--- a/app/models/typo.rb
+++ b/app/models/typo.rb
@@ -9,6 +9,9 @@ class Typo < ApplicationRecord
   delegate :context, to: :sample
   delegate :site, to: :context
 
+  has_many :citations, as: :citing
+  has_many :references, through: :citations
+
   # Internal heirarchy
   belongs_to :parent, class_name: "Typo", optional: true
   has_many :children, class_name: "Typo", foreign_key: "typo_id"

--- a/app/views/c14_labs/index.html.erb
+++ b/app/views/c14_labs/index.html.erb
@@ -24,5 +24,7 @@
 
   <%#= pagy_bootstrap_nav(@pagy) %>
 
-  <%= link_to 'New radiocarbon lab', new_c14_lab_path, class: 'btn btn-secondary', data: { "turbo_frame": "remote_modal" } %>
+  <% if can? :create, C14Lab %>
+    <%= link_to 'New radiocarbon lab', new_c14_lab_path, class: 'btn btn-secondary', data: { "turbo_frame": "remote_modal" } %>
+  <% end %>
 </div>

--- a/app/views/c14s/_table.html.erb
+++ b/app/views/c14s/_table.html.erb
@@ -1,6 +1,9 @@
 <table class="table table-hover">
   <thead>
     <tr>
+      <% unless controller_name == "sites" %>
+        <th scope=col>Site</th>
+      <% end %>
       <th scope=col>Lab ID</th>
       <th scope=col>Context</th>
       <th scope=col>Material</th>
@@ -15,6 +18,9 @@
   <tbody>
     <% c14s.each do |c14| %>
       <tr>
+        <% unless controller_name == "sites" %>
+          <td><%= link_to c14.site.name, c14.site %></td>
+        <% end %>
         <td><%= link_to c14.lab_identifier, c14 %></td>
         <td><%= c14.sample.context.name %></td>
         <td><%= c14.sample.material.present? ? c14.sample.material.name : na_value %></td>

--- a/app/views/c14s/index.html.erb
+++ b/app/views/c14s/index.html.erb
@@ -5,5 +5,8 @@
   <%= render "table", c14s: @c14s %>
 
   <%== pagy_bootstrap_nav(@pagy) %>
-  <%= link_to 'New C14 measurement', new_c14_path, class: 'btn btn-secondary' %>
+
+  <% if can? :create, C14 %>
+    <%= link_to 'New C14 measurement', new_c14_path, class: 'btn btn-secondary' %>
+  <% end %>
 </div>

--- a/app/views/references/_bibliography.html.erb
+++ b/app/views/references/_bibliography.html.erb
@@ -24,7 +24,7 @@
     <div class="tab-pane fade show active p-3 border border-top-0" id="biblio-text" role="tabpanel" aria-labelledby="biblio-text-tab" tabindex="-1">
       <ul class="list-unstyled mb-0">
         <% for ref in references %>
-          <li id="ref-<%= ref.short_ref %>">
+          <li id="<%= ref.anchor %>">
             <%= ref.render %>
             <small><%= link_to "[#{ref.short_ref}]", ref %></small>
           </li>

--- a/app/views/references/_citations.html.erb
+++ b/app/views/references/_citations.html.erb
@@ -2,6 +2,6 @@
   <%= na_value %>
 <% else %>
     <% for ref in references do %>
-      <a href="#ref-<%= ref.short_ref %>"><%= ref.render_citation %></a>
+      <a href="#<%= ref.anchor %>"><%= ref.render_citation %></a>
     <% end %>
 <% end %>

--- a/app/views/references/index.html.erb
+++ b/app/views/references/index.html.erb
@@ -26,7 +26,7 @@
     </tbody>
   </table>
 
-  <%#= pagy_bootstrap_nav(@pagy) %>
+  <%== pagy_bootstrap_nav(@pagy) %>
 
   <% if can? :create, Reference %>
     <%= link_to 'New reference', new_reference_path, class: 'btn btn-secondary',

--- a/app/views/references/index.html.erb
+++ b/app/views/references/index.html.erb
@@ -28,6 +28,8 @@
 
   <%#= pagy_bootstrap_nav(@pagy) %>
 
-  <%= link_to 'New reference', new_reference_path, class: 'btn btn-secondary',
-    data: { "turbo_frame": "remote_modal" } %>
+  <% if can? :create, Reference %>
+    <%= link_to 'New reference', new_reference_path, class: 'btn btn-secondary',
+      data: { "turbo_frame": "remote_modal" } %>
+  <% end %>
 </div>

--- a/app/views/references/index.html.erb
+++ b/app/views/references/index.html.erb
@@ -19,7 +19,7 @@
         <tr>
           <td><%= link_to reference.short_ref, reference %></td>
           <td><%= reference.render %></td>
-          <td><%= reference.citations.count %></td>
+          <td><%= reference.citations_count %></td>
           <% if can? :manage, Reference %><td class="text-end"><%= render 'shared/action_buttons_compact', i: reference %></td><% end %>
         </tr>
       <% end %>

--- a/app/views/references/show.html.erb
+++ b/app/views/references/show.html.erb
@@ -19,6 +19,25 @@
     <% c = @reference.citations.count %>
     <p>There <%= c > 1 ? 'are' : 'is' %> <%= c %> <%= 'record'.pluralize(c) %>
         in XRONOS that <%= c > 1 ? 'cite' : 'cites' %> this reference.</p>
+
+    <% unless @sites.blank? %>
+      <h3><%= Site.label.humanize.pluralize %> (<%= @sites.count %>)</h3>
+      <ul>
+      <% @sites.each do |site| %>
+        <li><%= link_to site.name, site %>, <%= render "sites/country", site: site %></li>
+      <% end %>
+      </ul>
+    <% end %>
+
+    <% unless @c14s.blank? %>
+      <h3><%= C14.label.humanize.pluralize %> (<%= @c14s.count %>)</h3>
+      <%= render "c14s/table", c14s: @c14s %>
+    <% end %>
+
+    <% unless @typos.blank? %>
+      <h3><%= Typo.label.humanize.pluralize %> (<%= @typos.count %>)</h3>
+      <%= render "typos/table", typos: @typos %>
+    <% end %>
   </div>
 </section>
 

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -30,5 +30,7 @@
 
   <%== pagy_bootstrap_nav(@pagy) %>
 
-  <%= link_to 'New site', new_site_path, class: 'btn btn-secondary' %>
+  <% if can? :create, Site %>
+    <%= link_to 'New site', new_site_path, class: 'btn btn-secondary' %>
+  <% end %>
 </div>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -35,19 +35,19 @@
 <section id="site-xrons" class="bg-light">
   <div class="container my-5">
 
-    <% unless @site.c14s.nil? %>
+    <% unless @c14s.nil? %>
       <section id="site-c14s" class="py-3">
         <h2><%= C14.label.humanize.pluralize %></h2>
-        <p><%= @site.name %> has <%= pluralize(@site.c14s.count, C14.label) %>.</p>
-        <%= render "c14s/table", c14s: @site.c14s %>
+        <p><%= @site.name %> has <%= pluralize(@c14s.count, C14.label) %>.</p>
+        <%= render "c14s/table", c14s: @c14s %>
       </section>
     <%end%>
 
-    <% unless @site.typos.nil? %>
+    <% unless @typos.nil? %>
       <section id="site-typos" class="py-3">
         <h2><%= Typo.label.humanize.pluralize %></h2>
-        <p><%= @site.name %> has <%= pluralize(@site.typos.count, Typo.label) %>.</p>
-        <%= render "typos/table", typos: @site.typos %>
+        <p><%= @site.name %> has <%= pluralize(@typos.count, Typo.label) %>.</p>
+        <%= render "typos/table", typos: @typos %>
       </section>
     <%end%>
 

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -7,15 +7,17 @@
   </div>
 </header>
 
-<section id="siteMap">
-  <div style="height: 30rem; position: relative;"
-       data-controller="map"
-       data-map-style-value="show_site"
-       data-map-target="container"
-       data-map-base-map-value="Imagery"
-       data-map-markers-data-value='<%= [@site].to_json.html_safe %>'>
-  </div>
-</section>
+<% unless @site.lat.blank? or @site.lng.blank? %>
+  <section id="siteMap">
+    <div style="height: 30rem; position: relative;"
+         data-controller="map"
+         data-map-style-value="show_site"
+         data-map-target="container"
+         data-map-base-map-value="Imagery"
+         data-map-markers-data-value='<%= [@site].to_json.html_safe %>'>
+    </div>
+  </section>
+<% end %>
 
 <section id="site-details" class="bg-body">
   <div class="container my-5">

--- a/app/views/source_databases/index.html.erb
+++ b/app/views/source_databases/index.html.erb
@@ -31,6 +31,8 @@
 
   <%#= pagy_bootstrap_nav(@pagy) %>
 
-  <%= link_to 'New source database', new_source_database_path, class: 'btn btn-secondary',
-    data: { "turbo_frame": "remote_modal" } %>
+  <% if can? :create, SourceDatabase %>
+    <%= link_to 'New source database', new_source_database_path, class: 'btn btn-secondary',
+      data: { "turbo_frame": "remote_modal" } %>
+  <% end %>
 </div>

--- a/app/views/source_databases/index.html.erb
+++ b/app/views/source_databases/index.html.erb
@@ -21,7 +21,7 @@
           <!--<td><%= link_to source_database.url, source_database.url, target: "_blank" %></td>-->
           <td><%= source_database.citation %></td>
           <td><%= source_database.licence %></td>
-          <td class="text-end"><%= source_database.c14s.count %></td>
+          <td class="text-end"><%= source_database.c14s_count %></td>
           <% if can? :manage, SourceDatabase %><td class="text-end"><%= render 'shared/action_buttons_compact', i: source_database %></td><% end %>
         </tr>
       <% end %>

--- a/app/views/typos/_table.html.erb
+++ b/app/views/typos/_table.html.erb
@@ -12,7 +12,7 @@
       <tr>
         <td><%= link_to typo.site.name, typo.site %></td>
         <td><%= link_to typo.name, typo %></td>
-        <td class="font-monospace text-end"><%= typo.age.present? ? type.age : na_value %></td>
+        <td class="font-monospace text-end"><%= typo.age.present? ? typo.age : na_value %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/typos/_table.html.erb
+++ b/app/views/typos/_table.html.erb
@@ -5,7 +5,8 @@
         <th scope=col>Site</th>
       <% end %>
       <th scope=col>Classification</th>
-      <th scope=col class="text-end">Estimated age</th>
+      <th scope=col>Estimated age</th>
+      <th scope=col class="text-end">References</th>
     </tr>
   </thead>
 
@@ -16,7 +17,8 @@
           <td><%= link_to typo.site.name, typo.site %></td>
         <% end %>
         <td><%= link_to typo.name, typo %></td>
-        <td class="font-monospace text-end"><%= typo.age.present? ? typo.age : na_value %></td>
+        <td class="font-monospace"><%= typo.age.present? ? typo.age : na_value %></td>
+        <td class="small text-end"><%= render "references/citations", references: typo.references %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/typos/_table.html.erb
+++ b/app/views/typos/_table.html.erb
@@ -1,7 +1,9 @@
 <table class="table table-hover">
   <thead>
     <tr>
-      <th scope=col>Site</th>
+      <% unless controller_name == "sites" %>
+        <th scope=col>Site</th>
+      <% end %>
       <th scope=col>Classification</th>
       <th scope=col class="text-end">Estimated age</th>
     </tr>
@@ -10,7 +12,9 @@
   <tbody>
     <% typos.each do |typo| %>
       <tr>
-        <td><%= link_to typo.site.name, typo.site %></td>
+        <% unless controller_name == "sites" %>
+          <td><%= link_to typo.site.name, typo.site %></td>
+        <% end %>
         <td><%= link_to typo.name, typo %></td>
         <td class="font-monospace text-end"><%= typo.age.present? ? typo.age : na_value %></td>
       </tr>

--- a/app/views/typos/index.html.erb
+++ b/app/views/typos/index.html.erb
@@ -6,6 +6,8 @@
 
   <%== pagy_bootstrap_nav(@pagy) %>
 
-  <%= link_to 'New typological date', new_typo_path, class: 'btn btn-secondary',
-    data: { "turbo_frame": "remote_modal" } %>
+  <% if can? :create, Typo %>
+    <%= link_to 'New typological date', new_typo_path, class: 'btn btn-secondary',
+      data: { "turbo_frame": "remote_modal" } %>
+  <% end %>
 </div>


### PR DESCRIPTION
- Fixes #102 
- Fixes #163 
- Fixes #114
- Optimises various queries  (thanks again bullet!): 
  - uses eager loading show and index views; 
  - preloaded association counts in index views (source databases, references).
- Improved references
  - Paginates the reference index view so that it is actually usable in production
  - Adds listings of citing records in reference show view, but this further exposes #168.
  - Implements association between typos and references and adds this to the index view and table partial
- Makes index table partials in general more portable
  - Adds a site column, unless we're in the sites controller
  - Except for sites #169