### PR TITLE
Add webpack as explicit dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -157,6 +157,7 @@ gem 'doorkeeper'
 
 # WebPacker for up-to-date asset serving
 gem 'webpacker'
+gem 'webpack', '>= 5.0'
 
 # Eye Candy
 gem 'bootstrap', '~> 5.1'


### PR DESCRIPTION
Fixes "peer dependency" error in yarn install. Hopefully allowing us to upgrade from node v12 #120