### PR TITLE
Fixing api crash sitetypes

### DIFF
--- a/app/views/api/v1/data/show.json.rabl
+++ b/app/views/api/v1/data/show.json.rabl
@@ -34,7 +34,7 @@ glue :sample do
       attributes :lat
       attributes :lng
       node :site_type do |site|
-        site.site_types.first.name
+        site.site_types.empty? ? "" : site.site_types.first.name
       end
     end
     child :typos => :periods do

--- a/spec/requests/api/v1/get_data_spec.rb
+++ b/spec/requests/api/v1/get_data_spec.rb
@@ -20,5 +20,20 @@ RSpec.describe 'Data', type: :request do
       expect(json.count).to eq C14.count
       expect(json).to match_response_schema('apiv1')
     end
+    
+    it 'processes a site without site' do
+      this_date = FactoryBot.create(:c14)
+      this_date.context.site = nil
+      get '/api/v1/data'
+      expect(response).to have_http_status(:success)
+    end
+    
+    it 'processes a site without site_types' do
+      this_date = FactoryBot.build(:c14)
+      this_date.sample.context.site.site_types = []
+      this_date.save
+      get '/api/v1/data'
+      expect(response).to have_http_status(:success)
+    end
   end
 end


### PR DESCRIPTION
Solving 500 with empty site types in API v1. Related to and solving #197.