### PR TITLE
Restore functionality to data browser

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -55,6 +55,7 @@ $enable-shadows: true;
 @import "typography";
 
 // Components
+@import "components";
 @import "slider";
 
 // View-specific

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,5 +53,8 @@ $enable-shadows: true;
 @import "layout";
 @import "typography";
 
+// Components
+@import "slider";
+
 // View-specific
 @import "data";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,6 +39,7 @@ $font-family-sans-serif:
 	sans-serif;
 
 $headings-font-family: "Raleway", $font-family-sans-serif;
+$enable-rounded: false;
 $enable-shadows: true;
 
 // Bootstrap

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1,0 +1,4 @@
+.collapse-status-open { display: initial; }
+.collapse-status-closed { display: none; }
+.collapsed .collapse-status-open { display: none; }
+.collapsed .collapse-status-closed { display: initial; }

--- a/app/assets/stylesheets/slider.scss
+++ b/app/assets/stylesheets/slider.scss
@@ -1,0 +1,22 @@
+/* Compensate for absolute-positioned pips */
+.has-slider::after {
+	content: "";
+	display: block;
+	height: 30px;
+}
+
+/* Only show tooltips when sliding handles */
+.noUi-tooltip {
+	display: none !important;
+}
+.noUi-active .noUi-tooltip {
+	display: block !important;
+}
+
+/* Nudge outer labels back inside parent box */
+.noUi-rtl .noUi-value-horizontal:nth-child(2) {
+	transform: translate(50%, 50%);
+}
+.noUi-rtl .noUi-value-horizontal:last-child {
+	transform: translate(90%, 50%);
+}

--- a/app/assets/stylesheets/slider.scss
+++ b/app/assets/stylesheets/slider.scss
@@ -17,10 +17,3 @@
 	display: block !important;
 }
 
-/* Nudge outer labels back inside parent box */
-.noUi-rtl .noUi-value-horizontal:nth-child(2) {
-	transform: translate(50%, 50%);
-}
-.noUi-rtl .noUi-value-horizontal:last-child {
-	transform: translate(90%, 50%);
-}

--- a/app/assets/stylesheets/slider.scss
+++ b/app/assets/stylesheets/slider.scss
@@ -1,3 +1,7 @@
+.noUi-connect {
+	background: $primary !important;
+}
+
 /* Compensate for absolute-positioned pips */
 .has-slider::after {
 	content: "";

--- a/app/controllers/c14_labs_controller.rb
+++ b/app/controllers/c14_labs_controller.rb
@@ -1,4 +1,5 @@
 class C14LabsController < ApplicationController
+  include Pagy::Backend
   include Tabulatable
 
   load_and_authorize_resource
@@ -11,6 +12,9 @@ class C14LabsController < ApplicationController
   def index
     @c14_labs = C14Lab.all
     respond_to do |format|
+      format.html {
+        @pagy, @c14_labs = pagy(@c14_labs)
+      }
       format.csv {
         @c14_labs = @c14_labs.select(index_csv_template)
         render csv: @c14_labs

--- a/app/controllers/data_controller.rb
+++ b/app/controllers/data_controller.rb
@@ -57,6 +57,10 @@ class DataController < ApplicationController
         :name,
         {name: []}
       ]},
+      {references: [
+        :short_ref,
+        {short_ref: []},
+      ]},
       {sites: [
         :name,
         {name: []},

--- a/app/controllers/data_controller.rb
+++ b/app/controllers/data_controller.rb
@@ -53,6 +53,10 @@ class DataController < ApplicationController
         :name,
         {name: []}
       ]},
+      {typos: [
+        :name,
+        {name: []}
+      ]},
       {sites: [
         :name,
         {name: []},

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -35,6 +35,28 @@ class ReferencesController < ApplicationController
     end
   end
 
+  # GET /c14s/search
+  # GET /c14s/search.json
+  def search
+    @references = Reference.with_citations_count.search(params[:q])
+
+    # order
+    if params.has_key?(:references_order_by)
+      order = { params[:references_order_by] => params.fetch(:references_order, "asc") }
+      @references = @references.reorder(order)
+    end
+
+    respond_to do |format|
+      format.html { 
+        @pagy, @references = pagy(@references)
+        render :index
+      }
+      format.json  {
+        render :index
+      }
+    end
+  end
+
   # GET /references/1
   # GET /references/1.json
   def show

--- a/app/controllers/typos_controller.rb
+++ b/app/controllers/typos_controller.rb
@@ -42,6 +42,22 @@ class TyposController < ApplicationController
     end
   end
 
+  # GET /typos/search
+  # GET /typos/search.json
+  def search
+    @typos = Typo.search(params[:q])
+
+    respond_to do |format|
+      format.html { 
+        @pagy, @typos = pagy(@typos)
+        render :index
+      }
+      format.json  {
+        render :index
+      }
+    end
+  end
+
   # GET /typos/1
   # GET /typos/1.json
   def show

--- a/app/helpers/bootstrap_helper.rb
+++ b/app/helpers/bootstrap_helper.rb
@@ -1,7 +1,7 @@
 module BootstrapHelper
 
   def accordion_item(id, title, collapsed = true)
-    content_tag :div, class: "accordion-item" do
+    content_tag :div, class: "accordion-item bg-transparent border-0" do
       header = accordion_header id, title, collapsed
       collapse = accordion_collapse id, collapsed do
         yield
@@ -28,7 +28,7 @@ module BootstrapHelper
   end
 
   def accordion_button(id, title, collapsed)
-    classes = [ "accordion-button", "bg-body" ]
+    classes = [ "accordion-button", "bg-transparent" ]
     classes.push("collapsed") if collapsed
     button_tag title, name: nil, class: classes.join(" "), type: :button,
       data: { bs_toggle: "collapse", bs_target: "#" + id.to_s },

--- a/app/helpers/bootstrap_helper.rb
+++ b/app/helpers/bootstrap_helper.rb
@@ -1,10 +1,53 @@
 module BootstrapHelper
 
+  def accordion_item(id, title, collapsed = true)
+    content_tag :div, class: "accordion-item" do
+      header = accordion_header id, title, collapsed
+      collapse = accordion_collapse id, collapsed do
+        yield
+      end
+      header + collapse
+    end
+  end
+
+
   def spinner
     content_tag :div, class: "spinner-border spinner-border-sm text-info", role: "status" do
       content_tag :span, class: "visually-hidden" do
         "Loading..."
       end
+    end
+  end
+
+  protected
+
+  def accordion_header(id, title, collapsed)
+    content_tag :h2, class: "accordion-header" do
+      accordion_button id, title, collapsed
+    end
+  end
+
+  def accordion_button(id, title, collapsed)
+    classes = [ "accordion-button" ]
+    classes.push("collapsed") if collapsed
+    button_tag title, name: nil, class: classes.join(" "), type: :button,
+      data: { bs_toggle: "collapse", bs_target: "#" + id.to_s },
+      aria: { expanded: !collapsed, controls: id }
+  end
+
+  def accordion_collapse(id, collapsed)
+    classes = [ "accordion-collapse", "collapse" ]
+    classes.push("show") unless collapsed
+    content_tag :div, id: id, class: classes.join(" ") do
+      accordion_body do
+        yield
+      end
+    end
+  end
+
+  def accordion_body
+    content_tag :div, class: "accordion-body" do
+      yield
     end
   end
 

--- a/app/helpers/bootstrap_helper.rb
+++ b/app/helpers/bootstrap_helper.rb
@@ -28,7 +28,7 @@ module BootstrapHelper
   end
 
   def accordion_button(id, title, collapsed)
-    classes = [ "accordion-button" ]
+    classes = [ "accordion-button", "bg-body" ]
     classes.push("collapsed") if collapsed
     button_tag title, name: nil, class: classes.join(" "), type: :button,
       data: { bs_toggle: "collapse", bs_target: "#" + id.to_s },

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,29 +4,32 @@
 
 import { application } from "./application"
 
-import ArticleEditorController from "./article_editor_controller.js"
+import ArticleEditorController from "./article_editor_controller"
 application.register("article-editor", ArticleEditorController)
 
-import FlashController from "./flash_controller.js"
+import FlashController from "./flash_controller"
 application.register("flash", FlashController)
 
-import HomeHeroController from "./home_hero_controller.js"
+import HomeHeroController from "./home_hero_controller"
 application.register("home-hero", HomeHeroController)
 
-import MapController from "./map_controller.js"
+import MapController from "./map_controller"
 application.register("map", MapController)
 
-import MarkdownEditorController from "./markdown_editor_controller.js"
+import MarkdownEditorController from "./markdown_editor_controller"
 application.register("markdown-editor", MarkdownEditorController)
 
-import RemoteModalController from "./remote_modal_controller.js"
+import RemoteModalController from "./remote_modal_controller"
 application.register("remote-modal", RemoteModalController)
 
-import TomSelectController from "./tom_select_controller.js"
+import SliderController from "./slider_controller"
+application.register("slider", SliderController)
+
+import TomSelectController from "./tom_select_controller"
 application.register("tom-select", TomSelectController)
 
-import TooltipsController from "./tooltips_controller.js"
+import TooltipsController from "./tooltips_controller"
 application.register("tooltips", TooltipsController)
 
-import VegaController from "./vega_controller.js"
+import VegaController from "./vega_controller"
 application.register("vega", VegaController)

--- a/app/javascript/controllers/slider_controller.js
+++ b/app/javascript/controllers/slider_controller.js
@@ -1,0 +1,70 @@
+import { Controller } from "@hotwired/stimulus"
+import noUiSlider from "nouislider";
+import "nouislider/dist/nouislider.css";
+import wNumb from "wnumb";
+
+// Connects to data-controller="slider"
+export default class extends Controller {
+	static targets = [ "minInput", "maxInput", "slider" ]
+	static values = {
+		step: Number,
+		direction: String,
+		formatter: String,
+		range: Object,
+		density: Number
+	}
+
+  connect() {
+		this.element.classList.add("has-slider");
+
+		var minInput = this.minInputTarget;
+		var maxInput = this.maxInputTarget;
+
+		// slider parameters
+		var step = (this.stepValue != 0 ? this.stepValue : 1);
+		var direction = (this.directionValue != '' ? this.directionValue : 'ltr');
+		var range = (this.hasRangeValue ? this.rangeValue : this.defaultRange());
+		var density = (this.densityValue != 0 ? this.densityValue : 1);
+
+		this.slider = noUiSlider.create(this.sliderTarget, {
+			start: [minInput.value, maxInput.value],
+			connect: true,
+			step: step,
+			direction: direction,
+			tooltips: this.formatter(),
+			range: range,
+			pips: {
+				mode: 'range',
+				density: density
+			}
+		});
+
+		this.slider.on('update', function(values, handle) {
+			minInput.value = values[0];
+			maxInput.value = values[1];
+		})
+	}
+
+	disconnect() {
+
+	}
+
+	formatter() {
+		var formatters = {
+			"integer": wNumb({ decimal: 0 }),
+			"uncalBP": wNumb({
+				decimal: 0,
+				thousands: "&thinsp;",
+				suffix: " uncal BP"
+			})
+		}
+		return formatters[this.formatterValue];
+	}
+
+	defaultRange() {
+		return { 
+			'min': Number(this.minInputTarget.min), 
+			'max': Number(this.minInputTarget.max) 
+		};
+	}
+}

--- a/app/javascript/controllers/slider_controller.js
+++ b/app/javascript/controllers/slider_controller.js
@@ -35,7 +35,8 @@ export default class extends Controller {
 			range: range,
 			pips: {
 				mode: 'range',
-				density: density
+				density: density,
+				format: this.formatter()
 			}
 		});
 
@@ -54,8 +55,7 @@ export default class extends Controller {
 			"integer": wNumb({ decimal: 0 }),
 			"uncalBP": wNumb({
 				decimal: 0,
-				thousands: "&thinsp;",
-				suffix: " uncal BP"
+				thousand: "&thinsp;"
 			})
 		}
 		return formatters[this.formatterValue];

--- a/app/models/data.rb
+++ b/app/models/data.rb
@@ -34,7 +34,7 @@ class Data
   def filters=(value)
     filters = value.to_h
     filters = deep_compact(filters)
-    #filters = decode_range_filters(filters)
+    filters = decode_range_filters(filters)
     filters = decode_array_filters(filters)
 
     @filters = filters
@@ -88,7 +88,8 @@ class Data
   end
 
   def slice_ranges(x)
-    x.each_slice(2).map { |n| 
+    x.map! { |i| i.to_i }
+    x = x.each_slice(2).map { |n| 
       return n[0] if n.length == 1
       n = n.sort
       n[0]..n[1] 

--- a/app/models/data.rb
+++ b/app/models/data.rb
@@ -89,10 +89,13 @@ class Data
 
   def slice_ranges(x)
     x.map! { |i| i.to_i }
-    x = x.each_slice(2).map { |n| 
-      return n[0] if n.length == 1
-      n = n.sort
-      n[0]..n[1] 
+    x.each_slice(2).map { |n| 
+      if n.length == 1
+        n[0]..n[0]
+      else
+        n.sort!
+        n[0]..n[1] 
+      end
     }
   end
 

--- a/app/models/typo.rb
+++ b/app/models/typo.rb
@@ -37,6 +37,12 @@ class Typo < ApplicationRecord
   belongs_to :parent, class_name: "Typo", optional: true
   has_many :children, class_name: "Typo", foreign_key: "typo_id"
 
+  include PgSearch::Model
+  pg_search_scope :search, 
+    against: :name, 
+    using: { tsearch: { prefix: true } } # match partial words
+  #multisearchable against: :name # needs to be cleaned up a bit more
+
   def self.label
     "typological date"
   end

--- a/app/views/data/_filter_fields.html.erb
+++ b/app/views/data/_filter_fields.html.erb
@@ -5,7 +5,7 @@
   </div>
 </noscript>
 
-<%= accordion_item "dataFilters-Site", "Site", false do %>
+<%= accordion_item "dataFilters-Site", "Sites", false do %>
 
   <%= f.fields_for :sites do |f| %>
 
@@ -20,18 +20,6 @@
         "tom-select-search-value": "name"
       } 
     %>
-
-    <div class="mb-3">
-      <%= f.label :country_code, "Countries", class: "form-label" %>
-      <%= f.country_select :country_code, 
-        { selected: @data.filter_value(:sites, :country_code) },
-        { 
-          class: "form-select",
-          multiple: true,
-          data: { controller: "tom-select" }
-        }
-      %>
-    </div>
 
   <% end %>
 
@@ -49,6 +37,24 @@
     %>
   <% end %>
 
+<% end %>
+
+<%= accordion_item "dataFiltersLocation", "Location", false do %>
+  <%= f.fields_for :sites do |f| %>
+
+    <div class="mb-3">
+      <%= f.label :country_code, "Countries", class: "form-label" %>
+      <%= f.country_select :country_code, 
+        { selected: @data.filter_value(:sites, :country_code) },
+        { 
+          class: "form-select",
+          multiple: true,
+          data: { controller: "tom-select" }
+        }
+      %>
+    </div>
+
+  <% end %>
 <% end %>
 
 <%= accordion_item "dataFiltersSample", "Sample", false do %>

--- a/app/views/data/_filter_fields.html.erb
+++ b/app/views/data/_filter_fields.html.erb
@@ -161,6 +161,11 @@
   <% end %>
 <% end %>
 
+<%# The following don't have a straightforward association to C14s and are
+    disabled pending a better solution to:
+    https://github.com/xronos-ch/xronos.rails/issues/165 %>
+<% if false %>
+
 <%= accordion_item "dataFilters-Typo", "Typochronology", true do %>
   <%= f.fields_for :typos do |f| %>
 
@@ -195,4 +200,6 @@
     %>
 
   <% end %>
+<% end %>
+
 <% end %>

--- a/app/views/data/_filter_fields.html.erb
+++ b/app/views/data/_filter_fields.html.erb
@@ -112,20 +112,45 @@
       }
     %>
 
-    <%= f.fields_for :bp do |f| %>
-      <%= f.number_field nil, label: "Minimum radiocarbon age",
-        append: "uncal BP",
-        min: 0,
-        max: 50000,
-        value: @data.filter_value(:c14s, :bp).present? ? @data.filter_value(:c14s, :bp)[0].min : 0 %>
+    <%# TODO: abstract as a helper or FormBuilder extension %>
+    <div class="mb-3"
+         data-controller="slider" 
+         data-slider-formatter-value="uncalBP"
+         data-slider-step-value=10
+         data-slider-direction-value=rtl
+         data-slider-range-value='{ "min": [0, 20], "25%": [2000, 100], "50%": [10000, 250], "75%": [30000, 500], "max": 50000 }'
+         data-slider-density-value=2>
 
-      <%= f.number_field nil, label: "Maximum radiocarbon age",
-        append: "uncal BP",
-        min: 0,
-        max: 50000,
-        value: @data.filter_value(:c14s, :bp).present? ? @data.filter_value(:c14s, :bp)[0].max : 50000 %>
+      <%= f.fields_for :bp do |f| %>
+        <%= f.hidden_field nil, data: { slider_target: "minInput" },
+          min: 0, max: 50000,
+          value: @data.filter_value(:c14s, :bp).present? ? @data.filter_value(:c14s, :bp)[0].min : 0 %>
+        <%= f.hidden_field nil, data: { slider_target: "maxInput" },
+          min: 0, max: 50000,
+          value: @data.filter_value(:c14s, :bp).present? ? @data.filter_value(:c14s, :bp)[0].max : 50000 %>
+      <% end %>
 
-    <% end %>
+      <label class="form-label" for="uncal_bp_slider">Radiocarbon age</label>
+      <div id="uncal_bp_slider" data-slider-target="slider"></div>
+
+    </div>
+    
+    <noscript>
+      <%# TODO: Switch to range fields if this is fixed:
+        https://github.com/bootstrap-ruby/bootstrap_form/issues/677 %>
+      <%= f.fields_for :bp do |f| %>
+        <%= f.number_field nil, label: "Minimum radiocarbon age",
+          append: "uncal BP",
+          min: 0,
+          max: 50000,
+          value: @data.filter_value(:c14s, :bp).present? ? @data.filter_value(:c14s, :bp)[0].min : 0 %>
+        <%= f.number_field nil, label: "Maximum radiocarbon age",
+          append: "uncal BP",
+          min: 0,
+          max: 50000,
+          value: @data.filter_value(:c14s, :bp).present? ? @data.filter_value(:c14s, :bp)[0].max : 50000 %>
+      <% end %>
+    </noscript>
 
   <% end %>
 

--- a/app/views/data/_filter_fields.html.erb
+++ b/app/views/data/_filter_fields.html.erb
@@ -5,108 +5,116 @@
   </div>
 </noscript>
 
-<%= f.fields_for :sites do |f| %>
+<%= accordion_item "dataFilters-Site", "Site", false do %>
 
-  <%= f.text_field :name, label: "Sites", 
-    value: @data.filter_value_string(:sites, :name),
-    multiple: true,
-    data: { 
-      controller: "tom-select",
-      "tom-select-route-value": "sites/search",
-      "tom-select-value-value": "name",
-      "tom-select-label-value": "name",
-      "tom-select-search-value": "name"
-    } 
-  %>
+  <%= f.fields_for :sites do |f| %>
 
-  <div class="mb-3">
-    <%= f.label :country_code, "Countries", class: "form-label" %>
-    <%= f.country_select :country_code, 
-      { selected: @data.filter_value(:sites, :country_code) },
+    <%= f.text_field :name, label: "Site names", 
+      value: @data.filter_value_string(:sites, :name),
+      multiple: true,
+      data: { 
+        controller: "tom-select",
+        "tom-select-route-value": "sites/search",
+        "tom-select-value-value": "name",
+        "tom-select-label-value": "name",
+        "tom-select-search-value": "name"
+      } 
+    %>
+
+    <div class="mb-3">
+      <%= f.label :country_code, "Countries", class: "form-label" %>
+      <%= f.country_select :country_code, 
+        { selected: @data.filter_value(:sites, :country_code) },
+        { 
+          class: "form-select",
+          multiple: true,
+          data: { controller: "tom-select" }
+        }
+      %>
+    </div>
+
+  <% end %>
+
+  <%= f.fields_for :site_types do |f| %>
+    <%= f.text_field :name, label: "Site types", 
+      value: @data.filter_value_string(:site_types, :name),
+      multiple: true,
+      data: {
+        controller: "tom-select",
+        "tom-select-route-value": "site_types/search",
+        "tom-select-value-value": "name",
+        "tom-select-label-value": "name",
+        "tom-select-search-value": "name"
+      }
+    %>
+  <% end %>
+
+<% end %>
+
+<%= accordion_item "dataFiltersSample", "Sample", false do %>
+
+  <%= f.fields_for :materials do |f| %>
+    <%= f.text_field :name, label: "Materials", 
+      value: @data.filter_value_string(:materials, :name),
+      multiple: true,
+      data: {
+        controller: "tom-select",
+        "tom-select-route-value": "materials/search",
+        "tom-select-value-value": "name",
+        "tom-select-label-value": "name",
+        "tom-select-search-value": "name"
+      }
+    %>
+  <% end %>
+
+  <%= f.fields_for :taxons do |f| %>
+    <%= f.text_field :name, label: "Taxons", 
+      value: @data.filter_value_string(:taxons, :name),
+      multiple: true,
+      data: {
+        controller: "tom-select",
+        "tom-select-route-value": "taxons/search",
+        "tom-select-value-value": "name",
+        "tom-select-label-value": "name",
+        "tom-select-search-value": "name"
+      }
+    %>
+  <% end %>
+
+<% end %>
+
+<%= accordion_item "dataFilters-C14", "Radiocarbon", false do %>
+  <%= f.fields_for :c14_labs do |f| %>
+    <%= f.collection_select :name, C14Lab.all, :name, :name,
+      {
+        label: "Labs",
+        selected: @data.filter_value(:c14_labs, :name),
+        include_blank: true,
+      },
       { 
-        class: "form-select",
         multiple: true,
         data: { controller: "tom-select" }
       }
     %>
-  </div>
+  <% end %>
 
-<% end %>
+  <%= f.fields_for :c14s do |f| %>
 
-<%= f.fields_for :site_types do |f| %>
-  <%= f.text_field :name, label: "Site types", 
-    value: @data.filter_value_string(:site_types, :name),
-    multiple: true,
-    data: {
-      controller: "tom-select",
-      "tom-select-route-value": "site_types/search",
-      "tom-select-value-value": "name",
-      "tom-select-label-value": "name",
-      "tom-select-search-value": "name"
-    }
-  %>
-<% end %>
-
-<%= f.fields_for :materials do |f| %>
-  <%= f.text_field :name, label: "Sample materials", 
-    value: @data.filter_value_string(:materials, :name),
-    multiple: true,
-    data: {
-      controller: "tom-select",
-      "tom-select-route-value": "materials/search",
-      "tom-select-value-value": "name",
-      "tom-select-label-value": "name",
-      "tom-select-search-value": "name"
-    }
-  %>
-<% end %>
-
-<%= f.fields_for :taxons do |f| %>
-  <%= f.text_field :name, label: "Sample taxa", 
-    value: @data.filter_value_string(:taxons, :name),
-    multiple: true,
-    data: {
-      controller: "tom-select",
-      "tom-select-route-value": "taxons/search",
-      "tom-select-value-value": "name",
-      "tom-select-label-value": "name",
-      "tom-select-search-value": "name"
-    }
-  %>
-<% end %>
-
-<%= f.fields_for :c14_labs do |f| %>
-  <%= f.collection_select :name, C14Lab.all, :name, :name,
-    {
-      label: "Labs",
-      selected: @data.filter_value(:c14_labs, :name),
-      include_blank: true,
-    },
-    { 
+    <%= f.text_field :lab_identifier, label: "Lab IDs", 
+      value: @data.filter_value_string(:c14s, :lab_identifier),
       multiple: true,
-      data: { controller: "tom-select" }
-    }
-  %>
-<% end %>
+      data: {
+        controller: "tom-select",
+        "tom-select-route-value": "c14s/search",
+        "tom-select-value-value": "lab_identifier",
+        "tom-select-label-value": "lab_identifier",
+        "tom-select-search-value": "lab_identifier"
+      }
+    %>
 
-<%= f.fields_for :c14s do |f| %>
+    <%# f.number_field :bp, label: "Uncalibrated age", append: "uncal BP", 
+      value: @data.filter_value_string(:sites, :contexts, :samples, :c14s, :bp) %>
 
-  <%= f.text_field :lab_identifier, label: "Lab IDs", 
-    value: @data.filter_value_string(:c14s, :lab_identifier),
-    multiple: true,
-    data: {
-      controller: "tom-select",
-      "tom-select-route-value": "c14s/search",
-      "tom-select-value-value": "lab_identifier",
-      "tom-select-label-value": "lab_identifier",
-      "tom-select-search-value": "lab_identifier"
-    }
-  %>
-
-  <%# f.number_field :bp, label: "Uncalibrated age", append: "uncal BP", 
-    value: @data.filter_value_string(:sites, :contexts, :samples, :c14s, :bp) %>
-
-  <%# f.number_field :cal_bp, label: "Calibrated age", append: "cal BP", 
-    value: @data.filter_value_string(:sites, :contexts, :samples, :c14s, :bp) %>
+  <% end %>
 
 <% end %>

--- a/app/views/data/_filter_fields.html.erb
+++ b/app/views/data/_filter_fields.html.erb
@@ -117,13 +117,13 @@
         append: "uncal BP",
         min: 0,
         max: 50000,
-        value: @data.filter_value(:c14s, :bp)[0].min %>
+        value: @data.filter_value(:c14s, :bp).present? ? @data.filter_value(:c14s, :bp)[0].min : 0 %>
 
       <%= f.number_field nil, label: "Maximum radiocarbon age",
         append: "uncal BP",
         min: 0,
         max: 50000,
-        value: @data.filter_value(:c14s, :bp)[0].max %>
+        value: @data.filter_value(:c14s, :bp).present? ? @data.filter_value(:c14s, :bp)[0].max : 50000 %>
 
     <% end %>
 

--- a/app/views/data/_filter_fields.html.erb
+++ b/app/views/data/_filter_fields.html.erb
@@ -136,8 +136,8 @@
           value: @data.filter_value(:c14s, :bp).present? ? @data.filter_value(:c14s, :bp)[0].max : 50000 %>
       <% end %>
 
-      <label class="form-label" for="uncal_bp_slider">Radiocarbon age</label>
-      <div id="uncal_bp_slider" data-slider-target="slider"></div>
+      <label class="form-label" for="uncal_bp_slider">Radiocarbon age <span class="text-muted">(uncal BP)</span></label>
+      <div class="mx-3 my-1" id="uncal_bp_slider" data-slider-target="slider"></div>
 
     </div>
     

--- a/app/views/data/_filter_fields.html.erb
+++ b/app/views/data/_filter_fields.html.erb
@@ -159,5 +159,23 @@
     </noscript>
 
   <% end %>
-
 <% end %>
+
+<%= accordion_item "dataFilters-Typo", "Typochronology", false do %>
+  <%= f.fields_for :typos do |f| %>
+
+    <%= f.text_field :name, label: "Typochronological unit", 
+      value: @data.filter_value_string(:typos, :name),
+      multiple: true,
+      data: { 
+        controller: "tom-select",
+        "tom-select-route-value": "typos/search",
+        "tom-select-value-value": "name",
+        "tom-select-label-value": "name",
+        "tom-select-search-value": "name"
+      } 
+    %>
+
+  <% end %>
+<% end %>
+

--- a/app/views/data/_filter_fields.html.erb
+++ b/app/views/data/_filter_fields.html.erb
@@ -179,3 +179,20 @@
   <% end %>
 <% end %>
 
+<%= accordion_item "dataFilters-Reference", "Bibliography", true do %>
+  <%= f.fields_for :references do |f| %>
+
+    <%= f.text_field :short_ref, label: "References", 
+      value: @data.filter_value_string(:references, :short_ref),
+      multiple: true,
+      data: { 
+        controller: "tom-select",
+        "tom-select-route-value": "references/search",
+        "tom-select-value-value": "short_ref",
+        "tom-select-label-value": "short_ref",
+        "tom-select-search-value": "short_ref"
+      } 
+    %>
+
+  <% end %>
+<% end %>

--- a/app/views/data/_filter_fields.html.erb
+++ b/app/views/data/_filter_fields.html.erb
@@ -5,7 +5,7 @@
   </div>
 </noscript>
 
-<%= accordion_item "dataFilters-Site", "Sites", false do %>
+<%= accordion_item "dataFilters-Site", "Sites", true do %>
 
   <%= f.fields_for :sites do |f| %>
 
@@ -57,7 +57,7 @@
   <% end %>
 <% end %>
 
-<%= accordion_item "dataFiltersSample", "Sample", false do %>
+<%= accordion_item "dataFiltersSample", "Sample", true do %>
 
   <%= f.fields_for :materials do |f| %>
     <%= f.text_field :name, label: "Materials", 
@@ -89,7 +89,7 @@
 
 <% end %>
 
-<%= accordion_item "dataFilters-C14", "Radiocarbon", false do %>
+<%= accordion_item "dataFilters-C14", "Radiocarbon", true do %>
   <%= f.fields_for :c14_labs do |f| %>
     <%= f.collection_select :name, C14Lab.all, :name, :name,
       {
@@ -161,7 +161,7 @@
   <% end %>
 <% end %>
 
-<%= accordion_item "dataFilters-Typo", "Typochronology", false do %>
+<%= accordion_item "dataFilters-Typo", "Typochronology", true do %>
   <%= f.fields_for :typos do |f| %>
 
     <%= f.text_field :name, label: "Typochronological unit", 

--- a/app/views/data/_filter_fields.html.erb
+++ b/app/views/data/_filter_fields.html.erb
@@ -112,8 +112,20 @@
       }
     %>
 
-    <%# f.number_field :bp, label: "Uncalibrated age", append: "uncal BP", 
-      value: @data.filter_value_string(:sites, :contexts, :samples, :c14s, :bp) %>
+    <%= f.fields_for :bp do |f| %>
+      <%= f.number_field nil, label: "Minimum radiocarbon age",
+        append: "uncal BP",
+        min: 0,
+        max: 50000,
+        value: @data.filter_value(:c14s, :bp)[0].min %>
+
+      <%= f.number_field nil, label: "Maximum radiocarbon age",
+        append: "uncal BP",
+        min: 0,
+        max: 50000,
+        value: @data.filter_value(:c14s, :bp)[0].max %>
+
+    <% end %>
 
   <% end %>
 

--- a/app/views/data/_filters.html.erb
+++ b/app/views/data/_filters.html.erb
@@ -3,9 +3,13 @@
 <div style="width: 30rem">
   <%= bootstrap_form_for :filter, method: :get, url: data_path do |f| %>
 
-    <%= render "filter_fields", f: f %>
+    <div class="accordion accordion-flush">
+      <%= render "filter_fields", f: f %>
+    </div>
 
-    <%= f.button "Filter", class: "btn btn-primary" %>
-    <%= link_to "Clear filters", data_path, class: "btn btn-danger" %>
+    <div class="m-3">
+      <%= f.button "Filter", class: "btn btn-primary" %>
+      <%= link_to "Clear filters", data_path, class: "btn btn-outline-danger" %>
+    </div>
   <% end %>
 </div>

--- a/app/views/data/_table.html.erb
+++ b/app/views/data/_table.html.erb
@@ -1,5 +1,3 @@
-<h2><%= @data.filters.any? ? "Filtered" : "All" %> records</h2>
-
 <%= turbo_frame_tag "data_table" do %>
   <table class="table">
 

--- a/app/views/data/_toolbar.html.erb
+++ b/app/views/data/_toolbar.html.erb
@@ -1,13 +1,25 @@
 <div class="d-flex">
-  <a class="navbar-brand link-dark" href="#">
+
+  <h1 class="h5 my-0 me-3 px-3 py-2 text-primary fw-bold">
     <%= fa_icon "hourglass-half" %>
     Data browser
-  </a>
+  </h1>
 
-  <ul class="nav nav-pills ms-3" role="tablist">
-    <li class="nav-item">
-      <a class="nav-link disabled text-dark">View:</a>
-    </li>
+  <button class="me-3 btn btn btn-outline-primary"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#dataFilters"
+          aria-expanded="true"
+          aria-controls="dataFilters">
+    <%= fa_icon "filter", text: "Filters" %>
+    <span class="collapse-status-open"><%= fa_icon "angle-left" %></span>
+    <span class="collapse-status-closed"><%= fa_icon "angle-right" %></span>
+  </button>
+
+  <div class="px-3 py-2 text-muted">
+    View:
+  </div>
+  <ul class="me-3 nav nav-pills" role="tablist">
     <li class="nav-item" role="presentation">
       <a id="dataMapTab" 
          class="nav-link active" 
@@ -17,7 +29,7 @@
          aria-controls="dataMap"
          aria-selected="true">
         <%= fa_icon "map-marker" %>
-        Map
+        Sites
       </a>
     </li>
     <li class="nav-item" role="presentation">
@@ -29,22 +41,12 @@
          aria-controls="dataTable"
          aria-selected="false">
         <%= fa_icon "table" %>
-        Table
+        Radiocarbon dates
       </a>
     </li>
   </ul>
 
-  <button class="btn btn-secondary ms-3"
-          type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#dataFilters"
-          aria-expanded="true"
-          aria-controls="dataFilters">
-    <%= fa_icon "filter" %>
-    Show/hide filters
-  </button>
-
-  <span class="navbar-text ms-3">
+  <span class="navbar-text me-3">
     <%= render "filter_status" %>
   </span>
 

--- a/app/views/data/index.html.erb
+++ b/app/views/data/index.html.erb
@@ -7,7 +7,7 @@
 <div class="flex-grow-1 d-flex">
 
   <aside id="dataFilters" 
-         class="collapse collapse-horizontal show p-3 bg-light border-end shadow-sm">
+         class="collapse collapse-horizontal show border-end shadow-sm">
     <%= render "filters" %>
   </aside>
 

--- a/app/views/data/index.html.erb
+++ b/app/views/data/index.html.erb
@@ -1,13 +1,13 @@
 <% content_for :title, "Browse data" %>
 <% content_for :meta_description, "Browse and download #{@data.everything.count} chronometric records from XRONOS, including radiocarbon dates, typological classifications, and dendrochronological dates. Filter by countries, specific archaeological site(s), site types, sample materials, sample taxa, radiocarbon laboratories, or laboratory IDs." %>
-<div class="px-3 py-2 bg-secondary border-bottom shadow-sm">
+
+<div class="px-1 py-2 border-bottom shadow-sm">
   <%= render "toolbar" %>
 </div>
 
 <div class="flex-grow-1 d-flex">
 
-  <aside id="dataFilters" 
-         class="collapse collapse-horizontal show border-end shadow-sm">
+  <aside id="dataFilters" class="collapse collapse-horizontal show bg-light">
     <%= render "filters" %>
   </aside>
 

--- a/app/views/references/_reference.json.jbuilder
+++ b/app/views/references/_reference.json.jbuilder
@@ -1,11 +1,2 @@
-json.extract! reference, :id, :bibtex, :short_ref, :created_at, :updated_at
+json.extract! reference, :id, :short_ref, :bibtex, :created_at, :updated_at
 
-json.measurements reference.measurements do |measurement|
-    json.(measurement, :id)
-end
-
-json.fell_phases reference.fell_phases do |fell_phase|
-    json.(fell_phase, :id)
-end
-
-json.url reference_url(reference, format: :json)

--- a/app/views/taxons/index.json.jbuilder
+++ b/app/views/taxons/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @taxons, partial: "taxons/taxon", as: :taxon

--- a/app/views/taxons/show.json.jbuilder
+++ b/app/views/taxons/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "taxons/taxon", taxon: @taxon

--- a/app/views/typos/_period.json.jbuilder
+++ b/app/views/typos/_period.json.jbuilder
@@ -1,7 +1,0 @@
-json.extract! period, :id, :name, :approx_start_time, :approx_end_time, :created_at, :updated_at
-
-json.site_phases period.site_phases do |site_phase|
-    json.(site_phase, :id)
-end
-
-json.url period_url(period, format: :json)

--- a/app/views/typos/_typo.json.jbuilder
+++ b/app/views/typos/_typo.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! typo, :id, :name, :approx_start_time, :approx_end_time, :created_at, :updated_at

--- a/app/views/typos/index.json.jbuilder
+++ b/app/views/typos/index.json.jbuilder
@@ -1,10 +1,1 @@
-json.set! :data do
-  json.array! @periods do |period|
-    json.partial! 'periods/period', period: period
-    json.url  "
-              #{link_to 'Show', period }
-              #{link_to 'Edit', edit_period_path(period)}
-              #{link_to 'Destroy', period, method: :delete, data: { confirm: 'Are you sure?' }}
-              "
-  end
-end
+json.array! @typos, partial: "typos/typo", as: :typo

--- a/app/views/typos/show.json.jbuilder
+++ b/app/views/typos/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! "periods/period", period: @period
+json.partial! "typos/typo", typo: @typo

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,9 @@ Rails.application.routes.draw do
   resources :site_types do
     get 'search', on: :collection
   end
-  resources :typos
+  resources :typos do
+    get 'search', on: :collection
+  end
 
   # Secondary data resources (no independent show/index views)
   resources :taxons, except: [:index, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,9 @@ Rails.application.routes.draw do
     get 'search', on: :collection
   end
   resources :measurement_states
-  resources :references
+  resources :references do
+    get 'search', on: :collection
+  end
   resources :sites do
     get 'search', on: :collection
   end

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
 		"leaflet-lasso": "^2.2.8",
 		"leaflet-providers": "^1.13.0",
 		"leaflet-spin": "^1.1.2",
+		"nouislider": "^15.7.0",
 		"rails-erb-loader": "^5.5.2",
 		"supercluster": "^7.1.5",
 		"tom-select": "^2.0.1",
 		"vega": "^5.23.0",
 		"vega-embed": "^6.21.2",
-		"vega-lite": "^5.6.0"
+		"vega-lite": "^5.6.0",
+		"wnumb": "^1.2.0"
 	},
 	"devDependencies": {
 		"webpack-dev-server": "^4.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,9 +2058,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001400:
-  version "1.0.30001443"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001443.tgz#8fc85f912d5471c9821acacf9e715c421ca0dd1f"
-  integrity sha512-jUo8svymO8+Mkj3qbUbVjR8zv8LUGpGkUM/jKvc9SO2BvjCI980dp9fQbf/dyLs6RascPzgR4nhAKFA4OHeSaA==
+  version "1.0.30001528"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001528.tgz"
+  integrity sha512-0Db4yyjR9QMNlsxh+kKWzQtkyflkG/snYheSzkjmvdEtEXB1+jt7A2HmSEiO6XIJPIbo92lHNGNySvE5pZcs5Q==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4961,6 +4961,11 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
+nouislider@^15.7.0:
+  version "15.7.0"
+  resolved "https://registry.yarnpkg.com/nouislider/-/nouislider-15.7.0.tgz#3d8ec43c6f767ceb7f17afc555016ef907cedc3d"
+  integrity sha512-aJVEULBPOUwq32/s7xnLNyLvo4kuzYJJsNp2PNGW932AQ0uuDAbLShAqswtxRzJc5n/dLJXNlYSLOZ57bcUg1w==
+
 npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
@@ -7935,6 +7940,11 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wnumb@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/wnumb/-/wnumb-1.2.0.tgz#f6fa5bfa739b9ca3b1e472094e1feeeb189484d9"
+  integrity sha512-eYut5K/dW7usfk/Mwm6nxBNoTPp/uP7PlXld+hhg7lDtHLdHFnNclywGYM9BRC7Ohd4JhwuHg+vmOUGfd3NhVA==
 
 worker-farm@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
Restores most of the filters the data browser had before it was refactored #288. Also includes some stylistic improvements to the data browser and related UI elements.

The outstanding issues are:

* Manual/lasso selections (#138), which I think would benefit from a wider framework for spatial filtering
* Filter by calibrated radiocarbon date (#138), depends on a solution to #46
* Filtering by typo (#297) or reference (#298). I couldn't figure out how to do this in a performant way using the current data model underlying the data browser. This is a now long-running issue (#165) that makes it difficult to add filters in general.