### PR TITLE
Speeding up api

### DIFF
--- a/app/controllers/api/v1/data_controller.rb
+++ b/app/controllers/api/v1/data_controller.rb
@@ -141,6 +141,8 @@ FROM (
   LEFT JOIN taxons ON taxons.id = samples.taxon_id
   LEFT JOIN contexts ON contexts.id = samples.context_id
   LEFT JOIN sites ON sites.id = contexts.site_id
+  LEFT JOIN site_types_sites ON site_types_sites.site_id = sites.id
+  LEFT JOIN site_types ON site_types_sites.site_type_id = site_types.id
 ] + where_clause + ") sub;"
 
                 #logger.debug C14.connection.exec_query(query).to_yaml

--- a/app/controllers/api/v1/data_controller.rb
+++ b/app/controllers/api/v1/data_controller.rb
@@ -75,7 +75,7 @@ module Api
           )
         end
         
-        where_clause = @data.to_sql[/ WHERE .*/]
+        where_clause = @data.to_sql[/ WHERE .*/].to_s
         
         query = %q[
 SELECT json_agg(json_build_object('measurement', measurement)) AS measurements

--- a/app/controllers/api/v1/data_controller.rb
+++ b/app/controllers/api/v1/data_controller.rb
@@ -145,9 +145,7 @@ FROM (
   LEFT JOIN site_types ON site_types_sites.site_type_id = site_types.id
 ] + where_clause + ") sub;"
 
-                #logger.debug C14.connection.exec_query(query).to_yaml
-        render json: C14.connection.exec_query(query)[0]['measurements'], adapter: nil, serializer: nil
-        
+        render json: C14.connection.exec_query(query)[0]['measurements'], adapter: nil, serializer: nil        
       end
 
       def show

--- a/app/controllers/api/v1/data_controller.rb
+++ b/app/controllers/api/v1/data_controller.rb
@@ -75,7 +75,77 @@ module Api
           )
         end
         
-        @data = @data.to_a
+        where_clause = @data.to_sql[/ WHERE .*/]
+        
+        query = %q[
+SELECT json_agg(json_build_object('measurement', measurement)) AS measurements
+FROM (
+  SELECT json_build_object(
+    'id', c14s.id,
+    'labnr', c14s.lab_identifier,
+    'bp', c14s.bp,
+    'std', c14s.std,
+    'cal_bp', c14s.cal_bp,
+    'cal_std', c14s.cal_std,
+    'delta_c13', c14s.delta_c13,
+    'source_database', '',
+    'lab_name', '',
+    'material', materials.name,
+    'species', taxons.name,
+    'feature', contexts.name,
+    'feature_type', (
+    SELECT st.name
+    FROM site_types st
+    JOIN site_types_sites sts ON st.id = sts.site_type_id
+    JOIN contexts ctx ON ctx.site_id = sts.site_id
+    JOIN samples samp ON samp.context_id = ctx.id
+    WHERE samp.id = samples.id AND st.name IS NOT NULL LIMIT 1
+    ),
+    'site', sites.name,
+    'country', sites.country_code,
+    'lat', sites.lat::text,
+    'lng', sites.lng::text,
+    'site_type', (
+      SELECT st.name
+      FROM site_types st
+      JOIN site_types_sites sts ON st.id = sts.site_type_id
+      JOIN contexts ctx ON ctx.site_id = sts.site_id
+      JOIN samples samp ON samp.context_id = ctx.id
+      WHERE samp.id = samples.id AND st.name IS NOT NULL LIMIT 1
+    ),
+    'periods', COALESCE((
+      SELECT json_agg(json_build_object('periode', tp.name))
+      FROM typos tp
+      WHERE tp.sample_id = samples.id
+    ), '[]'::json),
+    'typochronological_units', COALESCE((
+    SELECT json_agg(json_build_object('typochronological_unit', tp.name))
+      FROM typos tp
+      WHERE tp.sample_id = samples.id
+    ), '[]'::json),
+    'ecochronological_units', COALESCE((
+    SELECT json_agg(json_build_object('ecochronological_unit', tp.name))
+      FROM typos tp
+      WHERE tp.sample_id = samples.id
+    ), '[]'::json),
+    'reference', COALESCE((
+    SELECT json_agg(json_build_object('reference', ref.short_ref))
+      FROM "references" ref
+      JOIN citations cit ON ref.id = cit.reference_id
+      WHERE cit.citing_type = 'C14' AND cit.citing_id = c14s.id
+      ), '[]'::json)
+  ) AS measurement
+  FROM c14s
+  LEFT JOIN samples ON samples.id = c14s.sample_id
+  LEFT JOIN materials ON materials.id = samples.material_id
+  LEFT JOIN taxons ON taxons.id = samples.taxon_id
+  LEFT JOIN contexts ON contexts.id = samples.context_id
+  LEFT JOIN sites ON sites.id = contexts.site_id
+] + where_clause + ") sub;"
+
+                #logger.debug C14.connection.exec_query(query).to_yaml
+        render json: C14.connection.exec_query(query)[0]['measurements'], adapter: nil, serializer: nil
+        
       end
 
       def show


### PR DESCRIPTION
I have accelerated the API via direct output of json from SQL ( connected to a raw SQL query). That's got us in the R package from here:

`Time difference of 22.76668 secs`

to this one:

`Time difference of 6.365393 secs`

and in the backend from this:

`Completed 200 OK in 15886ms (Views: 2631.3ms | ActiveRecord: 786.8ms | Allocations: 16181837)`

to this one

`Completed 200 OK in 498ms (Views: 0.5ms | ActiveRecord: 353.7ms | Allocations: 51455)`

All on my laptop.

That is already a significant acceleration. Please check!