### PR TITLE
Csv and JSON download

### DIFF
--- a/app/controllers/c14s_controller.rb
+++ b/app/controllers/c14s_controller.rb
@@ -25,7 +25,11 @@ class C14sController < ApplicationController
     unless c14_params.blank?
       @c14s = @c14s.where(c14_params)
     end
-
+    
+#    if params[:sample_attributes][:context_attributes][:site_id].present?
+#      @c14s = @c14s.joins(sample: { context: :site }).where(sample:{context:{sites:{id: params[:sample_attributes][:context_attributes][:site_id]}}})
+#    end
+        
     # order
     if params.has_key?(:c14s_order_by)
       order = { params[:c14s_order_by] => params.fetch(:c14s_order, "asc") }
@@ -159,7 +163,13 @@ class C14sController < ApplicationController
           :position_y,
           :position_z,
           :position_crs
-        ]}
+        ]},
+        sample: [
+          :context_id,
+          contexts: [
+            :site_id
+          ]
+        ]
       )
     end
 

--- a/app/views/data/_toolbar.html.erb
+++ b/app/views/data/_toolbar.html.erb
@@ -51,8 +51,8 @@
     <%= render "filter_status" %>
   </span>
 
+  <ul class="nav">
   <!--
-  <ul class="nav ms-auto">
     <li class="nav-item dropdown">
       <a class="nav-link dropdown-toggle" 
          id="dataTools"  
@@ -67,6 +67,7 @@
         <li><a class="dropdown-item" href="#">Sum calibrate</a></li>
       </ul>
     </li>
+  -->
     <li class="nav-item dropdown">
       <a class="nav-link dropdown-toggle" 
          id="dataDownload"  
@@ -77,11 +78,30 @@
         <%= bs_icon "download" %>
         Download
       </a>
-      <ul class="dropdown-menu" aria-labelledby="dataDownload">
-        <li><a class="dropdown-item" href="#">CSV</a></li>
-        <li><a class="dropdown-item" href="#">XLSX</a></li>
+      <ul class="dropdown-menu" aria-labelledby="dataDownload" style="padding:0px;">
+        <li>
+			<div class="d-grid gap-2">
+			
+			<%= link_to data_path(format: :csv, filter: @raw_filter_params), 
+				class: "nav-link", 
+				title: "CSV",
+				download: "data_#{Date.today}.csv" do %>
+					<%=bs_icon("bi bi-filetype-csv")%> CSV
+			<% end %>
+		</div>
+	  </li>
+        <li>
+			<div class="d-grid gap-2">
+			
+			<%= link_to data_path(format: :json, filter: @raw_filter_params), 
+				class: "nav-link", 
+				title: "JSON",
+				download: "data_#{Date.today}.json" do %>
+					<%=bs_icon("bi bi-filetype-json")%> JSON
+			<% end%>
+		</div>
+	  </li>
       </ul>
     </li>
   </ul>
-  -->
 </div>


### PR DESCRIPTION
I reactivated the download, which is now fed via COPY from the materialised view of the data and is therefore sufficiently fast. At the same time, I took the opportunity to enable a json download. Both can be accessed via the already existing and only deactivated toolbar, which I have moved to the left, as it would otherwise have been covered by the leaflet selection window. I have also fixed the dysfunctional download from the site show view.

Please check!