### PR TITLE
Fix #346: Enable floating-point input for δ13C fields

### DIFF
--- a/app/views/c14s/_fields.html.erb
+++ b/app/views/c14s/_fields.html.erb
@@ -33,8 +33,8 @@
 </div>
 
 <div class="row">
-  <div class="col"><%= f.number_field :delta_c13, label: "δ13C", append: "‰" %></div>
-  <div class="col"><%= f.number_field :delta_c13_std, label: "δ13C error", prepend: "±" %></div>
+  <div class="col"><%= f.number_field :delta_c13, step: :any, label: "δ13C", append: "‰" %></div>
+  <div class="col"><%= f.number_field :delta_c13_std, step: :any, label: "δ13C error", prepend: "±" %></div>
 </div>
 
 <!-- TODO: source database -->


### PR DESCRIPTION
- Added  to allow precise values for `δ13C` and `δ13C error`.
- Resolves issue with decimal input (e.g., -27.9 ± 0.6).

Closes #346 