### PR TITLE
Fix DB schema version

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_15_102659) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_16_093633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"


### PR DESCRIPTION
I wanted to take a sneak peak at your work here (which looks great, by the way!) and came across an issue with the database migrations. It looks like the schema version was incorrectly de-incremented in [this merge](https://github.com/xronos-ch/xronos.rails/commit/47b1f5786fbcf2bb059195f89f75b0e82c272332#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3), which meant Rails wanted to run the migrations to create the 'dendros' and 'chronologies' tables even though they already exist in the schema. Re-incrementing the schema version fixes this and allows the database to be cleanly regenerated.