### PR TITLE
Simplify reference show view

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 ## 1.1.2.9000 [unreleased]
 
 - Upgraded Rails from 7.2.3 to 8.0.5 and enabled Rails 8.0 framework defaults.
+- Prevented duplicate citations from being created
 
 ## 1.1.2 [2026-05-29]
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,11 @@
 
 - Upgraded Rails from 7.2.3 to 8.0.5 and enabled Rails 8.0 framework defaults.
 - Prevented duplicate citations from being created
+  - Migration may fail if there are existing duplicates in the database. If so:
+      DRY_RUN=1 bin/rails citations:deduplicate 
+    checks for existing duplicates that would block this migration. And:
+      bin/rails citations:deduplicate 
+    deletes them.
 
 ## 1.1.2 [2026-05-29]
 

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -34,8 +34,8 @@ class ReferencesController < ApplicationController
     end
   end
 
-  # GET /c14s/search
-  # GET /c14s/search.json
+  # GET /references/search
+  # GET /references/search.json
   def search
     @references = Reference.with_citations_count.search(params[:q])
 
@@ -63,14 +63,8 @@ class ReferencesController < ApplicationController
 
     @citations_count = @reference.citations.count
 
-    @sites = @reference.sites.distinct
+    @sites = @reference.sites.distinct.with_counts
     @pagy_sites, @sites = pagy(:countish, @sites, page_param: :sites_page)
-
-    @c14s = @reference.c14s.includes([:references, sample: [:material, :taxon, context: [:site]]])
-    @pagy_c14s, @c14s = pagy(:countish, @c14s, page_param: :c14s_page)
-
-    @typos = @reference.typos.includes([:references, sample: [context: [:site]]])
-    @pagy_typos, @typos = pagy(:countish, @typos, page_param: :typos_page)
   end
 
   # GET /references/new

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -9,13 +9,20 @@
 #
 # Indexes
 #
-#  index_citations_on_citing        (citing_type,citing_id)
-#  index_citations_on_reference_id  (reference_id)
+#  index_citations_on_citing                (citing_type,citing_id)
+#  index_citations_on_citing_and_reference  (citing_type,citing_id,reference_id) UNIQUE
+#  index_citations_on_reference_id          (reference_id)
 #
 class Citation < ApplicationRecord
 
   belongs_to :citing, polymorphic: true
   belongs_to :reference
+
+  validates :reference,
+            uniqueness: {
+              scope: %i[citing_type citing_id],
+              message: "has already been cited for this record"
+            }
 
   acts_as_copy_target # enable CSV exports
 

--- a/app/views/references/show.html.erb
+++ b/app/views/references/show.html.erb
@@ -33,47 +33,9 @@
           <small class="text-muted">(<%= @pagy_sites.count %>)</small>
         </h3>
         <turbo-frame id="reference-sites-table">
-          <ul>
-            <% @sites.each do |site| %>
-              <li><%= link_to site.name, site %>, <%= render "sites/country", site: site %></li>
-            <% end %>
-          </ul>
+          <%= render "sites/table", sites: @sites %>
           <% unless @pagy_sites.pages <= 1 %>
             <%== @pagy_sites.series_nav(:bootstrap) %>
-          <% end %>
-        </turbo-frame>
-      </div>
-    <% end %>
-
-    <% if @c14s.present? %>
-      <div class="my-5">
-        <h3>
-          <%= xr_icon C14, {}, style: "height: 1.75rem; vertical-align: top;" %>
-          <%= C14.label.humanize.pluralize %>
-          <small class="text-muted">(<%= @pagy_c14s.count %>)</small>
-        </h3>
-				<turbo-frame id="reference-c14s-table">
-				  <% cache [@reference, :c14s, @pagy_c14s.page] do %>
-					    <%= render "c14s/table", c14s: @c14s %>
-				  <% end %>
-				  <% unless @pagy_c14s.pages <= 1 %>
-					  <%== @pagy_c14s.series_nav(:bootstrap) %>
-					<% end %>
-			  </turbo-frame>
-      </div>
-    <% end %>
-
-    <% if @typos.present? %>
-      <div class="my-5">
-        <h3>
-          <%= xr_icon Typo, {}, style: "height: 1.75rem; vertical-align: top;" %>
-          <%= Typo.label.humanize.pluralize %>
-          <small class="text-muted">(<%= @pagy_typos.count %>)</small>
-        </h3>
-        <turbo-frame id="reference-typos-table">
-          <%= render "typos/table", typos: @typos %>
-          <% unless @pagy_typos.pages <= 1 %>
-            <%== @pagy_typos.series_nav(:bootstrap) %>
           <% end %>
         </turbo-frame>
       </div>

--- a/app/views/sites/_table.html.erb
+++ b/app/views/sites/_table.html.erb
@@ -36,7 +36,7 @@
     <% sites.each do |site| %>
       <tr>
         <td><%= link_to site.name, site, target: :_top %></td>
-        <td><%= site.country.present? ? render("country", site: site) : na_value %></td>
+        <td><%= site.country.present? ? render("sites/country", site: site) : na_value %></td>
         <td class="font-monospace"><%= site.coordinates.present? ? site.coordinates : na_value %></td>
         <td class="text-end"><%= site.c14s_count %></td>
         <td class="text-end"><%= site.typos_count %></td>

--- a/db/migrate/20260601093343_add_unique_index_to_citations_on_citing_and_reference.rb
+++ b/db/migrate/20260601093343_add_unique_index_to_citations_on_citing_and_reference.rb
@@ -1,0 +1,15 @@
+class AddUniqueIndexToCitationsOnCitingAndReference < ActiveRecord::Migration[7.2]
+  # Run 
+  #     DRY_RUN=1 bin/rails citations:deduplicate 
+  # to check for existing duplicates that would block this migration.
+  #
+  # If any are found, run 
+  #     bin/rails citations:deduplicate 
+  # to delete them.
+  def change
+    add_index :citations,
+              %i[citing_type citing_id reference_id],
+              unique: true,
+              name: "index_citations_on_citing_and_reference"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_15_102659) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_01_093343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -105,6 +105,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_15_102659) do
     t.bigint "reference_id"
     t.string "citing_type"
     t.bigint "citing_id"
+    t.index ["citing_type", "citing_id", "reference_id"], name: "index_citations_on_citing_and_reference", unique: true
     t.index ["citing_type", "citing_id"], name: "index_citations_on_citing"
     t.index ["reference_id"], name: "index_citations_on_reference_id"
   end

--- a/lib/tasks/citations.rake
+++ b/lib/tasks/citations.rake
@@ -8,9 +8,10 @@ namespace :citations do
     puts
 
     duplicates = Citation
-      .select("MIN(id) AS keep_id, citing_type, citing_id, reference_id, COUNT(*) AS count")
+      .select("MIN(id) AS keep_id, citing_type, citing_id, reference_id, COUNT(*) AS duplicate_count")
       .group(:citing_type, :citing_id, :reference_id)
       .having("COUNT(*) > 1")
+      .to_a
 
     total_groups = duplicates.size
     total_rows   = duplicates.sum { |d| d.count - 1 }

--- a/lib/tasks/deduplicate_citations.rake
+++ b/lib/tasks/deduplicate_citations.rake
@@ -1,0 +1,47 @@
+namespace :citations do
+  desc "Remove duplicate citations (keeps the lowest id per citing + reference)"
+  task deduplicate: :environment do
+    dry_run = ENV["DRY_RUN"].present?
+
+    puts "== Citation deduplication =="
+    puts "Mode: #{dry_run ? 'DRY RUN (no changes)' : 'DELETE duplicates'}"
+    puts
+
+    duplicates = Citation
+      .select("MIN(id) AS keep_id, citing_type, citing_id, reference_id, COUNT(*) AS count")
+      .group(:citing_type, :citing_id, :reference_id)
+      .having("COUNT(*) > 1")
+
+    total_groups = duplicates.size
+    total_rows   = duplicates.sum { |d| d.count - 1 }
+
+    puts "Duplicate groups found: #{total_groups}"
+    puts "Rows to be removed:     #{total_rows}"
+    puts
+
+    if total_groups.zero?
+      puts "No duplicates found. Nothing to do."
+      next
+    end
+
+    duplicates.find_each(batch_size: 100) do |dup|
+      scope = Citation.where(
+        citing_type: dup.citing_type,
+        citing_id: dup.citing_id,
+        reference_id: dup.reference_id
+      ).where.not(id: dup.keep_id)
+
+      if dry_run
+        puts "Would delete #{scope.count} rows for " \
+             "#{dup.citing_type}(#{dup.citing_id}) → reference #{dup.reference_id}"
+      else
+        deleted = scope.delete_all
+        puts "Deleted #{deleted} rows for " \
+             "#{dup.citing_type}(#{dup.citing_id}) → reference #{dup.reference_id}"
+      end
+    end
+
+    puts
+    puts dry_run ? "Dry run completed." : "Deduplication completed."
+  end
+end

--- a/test/factories/citations.rb
+++ b/test/factories/citations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :citation do
+    association :reference
+    association :citing, factory: :site
+  end
+end
+

--- a/test/models/citation_test.rb
+++ b/test/models/citation_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class CitationTest < ActiveSupport::TestCase
+  test "does not allow duplicate citations for the same reference and citing record" do
+    citation = create(:citation)
+
+    duplicate = build(
+      :citation,
+      reference: citation.reference,
+      citing: citation.citing
+    )
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:reference], "has already been cited for this record"
+  end
+
+end


### PR DESCRIPTION
The reference show view now only lists sites, mitigating the performance issues caused by deep pagination with references with many citations (#402). To compensate, the sites are now listed in tabular form with c14 and typo counts.

Incidentally also fixed a bug where duplicated citations could be created (and therefore showing up in the count).