### PR TITLE
Exclude missing coordinates from data browser GeoJSON

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@
     checks for existing duplicates that would block this migration. And:
       bin/rails xronos:citations:deduplicate 
     deletes them.
+- Fixed data browser map display for records with missing coordinates.
 
 ## 1.1.2 [2026-05-29]
 

--- a/app/controllers/xronos_data_controller.rb
+++ b/app/controllers/xronos_data_controller.rb
@@ -138,20 +138,29 @@ class XronosDataController < ApplicationController
   end
 
   def build_geojson_from_sql(sites_sql)
+    geojson_sql = <<~SQL.squish
+    (
+      SELECT jsonb_build_object(
+        'type', 'Feature',
+        'geometry', jsonb_build_object(
+          'type', 'Point',
+          'coordinates', jsonb_build_array(lng, lat)
+        ),
+        'properties', jsonb_build_object(
+          'name', name,
+          'id', id
+        )
+      ) AS geojson
+      FROM (#{sites_sql}) AS subquery1
+      WHERE lat IS NOT NULL
+        AND lng IS NOT NULL
+    ) AS subquery2
+  SQL
+
     Site.connection.exec_query(
       Site
-        .select("json_agg(geojson) AS measurements")
-        .from("(select jsonb_build_object(
-          'type', 'Feature',
-          'geometry', jsonb_build_object(
-              'type', 'Point',
-              'coordinates', jsonb_build_array(lng, lat)
-          ),
-          'properties', jsonb_build_object(
-              'name', name,
-              'id', id
-          )
-        ) AS geojson from (#{sites_sql}) AS subquery1) AS subquery2")
+        .select("COALESCE(json_agg(geojson), '[]'::json) AS measurements")
+        .from(geojson_sql)
         .to_sql
     )[0]["measurements"]
   end


### PR DESCRIPTION
This fixes the data browser map placing records without coordinates at 0,0.

The underlying data view should still include records with missing coordinates, because they remain valid XRONOS records and should appear in table, JSON, and CSV views. The problem is only the GeoJSON/map layer: records without complete latitude/longitude values should not be emitted as map features.

The patch therefore filters `NULL` `lat`/`lng` values inside the GeoJSON construction and leaves the broader `@data.xrons` relation unchanged.