### PR TITLE
Escape site marker JSON in map data attribute

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
       bin/rails xronos:citations:deduplicate 
     deletes them.
 - Fixed data browser map display for records with missing coordinates.
+- Fixed Leaflet marker initialisation on site pages with quotation marks or apostrophes in site names.
 
 ## 1.1.2 [2026-05-29]
 

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -23,12 +23,13 @@
 
         <div class="col-lg-8">
           <% unless @site.lat.blank? || @site.lng.blank? %>
+            <% site_markers_data = json_escape([@site].to_json) %>
             <div style="height: 30rem; position: relative;"
                  data-controller="map"
                  data-map-style-value="show_site"
                  data-map-target="container"
                  data-map-base-map-value="Imagery"
-                 data-map-markers-data-value='<%= [@site].to_json.html_safe %>'>
+                 data-map-markers-data-value="<%= site_markers_data %>">
             </div>
           <% else %>
             <div style="height: 30rem; position: relative;"


### PR DESCRIPTION
Fixes #270.

The site show page passed marker data into a Stimulus data attribute using raw `to_json.html_safe`. Site names containing quotation marks or apostrophes could therefore break the HTML attribute and cause `JSON.parse` to receive truncated JSON.

This escapes the JSON payload before embedding it in the `data-map-markers-data-value` attribute, so quoted site names no longer break Leaflet marker initialisation.