### PR TITLE
Add article metadata for page titles and descriptions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
       bin/rails xronos:citations:deduplicate 
     deletes them.
 - Fixed data browser map display for records with missing coordinates.
+- Added article-specific page titles and meta descriptions for news, about, and documentation articles.
 
 ## 1.1.2 [2026-05-29]
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,3 +1,7 @@
+<% article_description = truncate(strip_tags(@article.body_html).squish.presence || @article.title, length: 160) %>
+<% content_for :title, @article.title %>
+<% content_for :meta_description, article_description %>
+
 <% if @article.splash.present? %>
   <% content_for :page_styles %>
   <style>


### PR DESCRIPTION
Fixes #394

Adds article-specific `<title>` and meta description content for news posts and about/docs pages, using the article title and a shortened plain-text version of the article body.