### PR TITLE
Add news feeds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
       REGISTRATION_PASSPHRASE: xronos
       ADMIN_USER_ID: 1
       ADMIN_USER_EMAIL: admin@xronos.ch
+      ADMIN_USER_PASSWORD: xronos
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ your_directory
 
 **db**: An empty directory that will contain the database.  
 **docker-compose.yml**: A `docker-compose.yml` file ([example](https://github.com/xronos-ch/xronos.rails/blob/f4049a7eb0ee2a6311a72ef5616e4692aa2cad52/docker-compose.yml))  
-**env_variables.env**: A file with environment variables.
+**env_variables.env**: A file with environment variables. Example:
 
 ```
 # Database credentials
@@ -39,6 +39,10 @@ POSTGRES_USER=...
 POSTGRES_PASSWORD=...
 # Passphrase the users must know to register
 REGISTRATION_PASSPHRASE=...
+# Default admin user (for bulk changes etc.)
+ADMIN_USER_ID=1
+ADMIN_USER_EMAIL=
+ADMIN_USER_PASSWORD=
 ```
 
 Inside of this directory you can then run

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -3,12 +3,28 @@ class ArticlesController < ApplicationController
   load_and_authorize_resource
 
   # GET /:section
+  # GET /:section.atom
+  # GET /:section.rss
   def index
     @articles = Article
       .published
       .where(section: params[:section])
       .order(published_at: :desc)
-    @pagy, @articles = pagy(:offset, @articles)
+
+    feed_limit = 20
+
+    respond_to do |format|
+      format.html {
+        @pagy, @articles = pagy(:offset, @articles, limit: feed_limit)
+      }
+      format.atom {
+        @pagy, @articles = pagy(:offset, @articles, limit: feed_limit)
+      }
+      format.rss {
+        @feed_limit = feed_limit
+      }
+    end
+
   end
 
   # GET /:section/:slug

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -63,11 +63,11 @@ class Article < ApplicationRecord
   }
 
   def published?
-    publish and published_at <= DateTime.now
+    publish and published_at <= Time.zone.now
   end
 
   def scheduled?
-    publish and published_at > DateTime.now
+    publish and published_at > Time.zone.now
   end
 
   def draft?

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -59,7 +59,7 @@ class Article < ApplicationRecord
 
   scope :published, -> { 
     where(publish: true)
-      .where("published_at <= ?", DateTime.now)
+      .where("published_at <= ?", Time.zone.now)
   }
 
   def published?

--- a/app/views/articles/index.atom.builder
+++ b/app/views/articles/index.atom.builder
@@ -3,10 +3,10 @@ atom_feed do |feed|
   feed.updated @articles.first&.published_at || Time.current
 
   # Pagination (atom only)
-  feed.link href: url_for(page: nil, format: :atom), rel: "alternate"
-  feed.link href: url_for(page: @pagy.page, format: :atom), rel: "self"
-  feed.link href: url_for(page: @pagy.next, format: :atom), rel: "next" if @pagy.next
-  feed.link href: url_for(page: @pagy.previous, format: :atom), rel: "prev" if @pagy.previous
+  feed.link href: news_url(page: nil, format: :atom), rel: "alternate"
+  feed.link href: news_url(page: @pagy.page, format: :atom), rel: "self"
+  feed.link href: news_url(page: @pagy.next, format: :atom), rel: "next" if @pagy.next
+  feed.link href: news_url(page: @pagy.previous, format: :atom), rel: "prev" if @pagy.previous
 
   @articles.first(@pagy.limit).each do |article|
     article_url = article_url section: article.section, slug: article.slug
@@ -24,12 +24,6 @@ atom_feed do |feed|
           author.uri(root_url)
         end
       end
-
-      entry.updated article.updated_at
-      entry.published article.published_at
-
-      entry.url article_url
-      entry.id article_url
     end
   end
 end

--- a/app/views/articles/index.atom.builder
+++ b/app/views/articles/index.atom.builder
@@ -1,0 +1,36 @@
+atom_feed do |feed|
+  feed.title("XRONOS – News")
+  feed.updated @articles.first&.published_at || Time.current
+
+  # Pagination (atom only)
+  feed.link href: url_for(page: nil, format: :atom), rel: "alternate"
+  feed.link href: url_for(page: @pagy.page, format: :atom), rel: "self"
+  feed.link href: url_for(page: @pagy.next, format: :atom), rel: "next" if @pagy.next
+  feed.link href: url_for(page: @pagy.previous, format: :atom), rel: "prev" if @pagy.previous
+
+  @articles.first(@pagy.limit).each do |article|
+    article_url = article_url section: article.section, slug: article.slug
+    feed.entry article, url: article_url do |entry|
+      entry.title article.title
+      entry.content article.body_html, type: "html"
+
+      entry.author do |author|
+        user_profile = article.user.user_profile
+        if user_profile.present? 
+          author.name user_profile.full_name
+          author.uri user_profiles_url(user_profile)
+        else
+          author.name("XRONOS")
+          author.uri(root_url)
+        end
+      end
+
+      entry.updated article.updated_at
+      entry.published article.published_at
+
+      entry.url article_url
+      entry.id article_url
+    end
+  end
+end
+

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,3 +1,8 @@
+<%= content_for :head do %>
+  <%= tag.link rel: "alternate", type: "application/atom+xml", href: url_for(format: :atom) %>
+  <%= tag.link rel: "alternate", type: "application/rss+xml", href: url_for(format: :rss) %>
+<% end %>
+
 <header>
   <div class="container my-5 d-flex flex-row">
     <div>

--- a/app/views/articles/index.rss.builder
+++ b/app/views/articles/index.rss.builder
@@ -1,11 +1,15 @@
 xml.instruct! :xml, version: "1.0", encoding: "UTF-8"
 
-xml.rss version: "2.0" do
+xml.rss version: "2.0", "xmlns:atom" => "http://www.w3.org/2005/Atom" do
   xml.channel do
     xml.title "XRONOS – News"
     xml.link root_url
     xml.description "Latest news from XRONOS, an open data infrastructure for archaeological chronology"
     xml.lastBuildDate (@articles.first&.published_at || Time.current).rfc2822
+
+    # Canonical URL
+    xml.tag! "atom:link", rel: "self", type: "application/rss+xml",
+      href: news_url(format: :rss)
 
     @articles.first(@feed_limit).each do |article|
       article_url = article_url(section: article.section, slug: article.slug)
@@ -14,10 +18,6 @@ xml.rss version: "2.0" do
         xml.title article.title
         xml.link article_url
         xml.guid article_url
-
-        # Canonical URL
-        xml.tag! "atom:link", rel: "self", type: "application/rss+xml",
-          href: news_url(format: :rss)
 
         xml.pubDate(article.published_at&.rfc2822 || article.updated_at.rfc2822)
 

--- a/app/views/articles/index.rss.builder
+++ b/app/views/articles/index.rss.builder
@@ -1,0 +1,38 @@
+xml.instruct! :xml, version: "1.0", encoding: "UTF-8"
+
+xml.rss version: "2.0" do
+  xml.channel do
+    xml.title "XRONOS – News"
+    xml.link root_url
+    xml.description "Latest news from XRONOS, an open data infrastructure for archaeological chronology"
+    xml.lastBuildDate (@articles.first&.published_at || Time.current).rfc2822
+
+    @articles.first(@feed_limit).each do |article|
+      article_url = article_url(section: article.section, slug: article.slug)
+
+      xml.item do
+        xml.title article.title
+        xml.link article_url
+        xml.guid article_url
+
+        # Canonical URL
+        xml.tag! "atom:link", rel: "self", type: "application/rss+xml",
+          href: news_url(format: :rss)
+
+        xml.pubDate(article.published_at&.rfc2822 || article.updated_at.rfc2822)
+
+        xml.description do
+          xml.cdata! article.body_html
+        end
+
+        user_profile = article.user.user_profile
+
+        if user_profile.present?
+          xml.author "#{user_profile.public_email} (#{user_profile.full_name})"
+        else
+          xml.author "admin@xronos.ch (XRONOS)"
+        end
+      end
+    end
+  end
+end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,3 +1,9 @@
+<%= content_for :head do %>
+  <!-- News feeds -->
+  <%= tag.link rel: "alternate", type: "application/atom+xml", href: news_url(format: :atom) %>
+  <%= tag.link rel: "alternate", type: "application/rss+xml", href: news_url(format: :rss) %>
+<% end %>
+
 <div class="jumbotron jumbotron-fluid hero mt-0 position-relative hero py-5 shadow">
 
   <div class="container h-100 d-flex flex-column" style="text-shadow: var(--bs-dark) 0 0 1rem;">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,10 @@ Rails.application.routes.draw do
 
   # Articles (news posts and other pseudo-static pages)
   get '/news', to: 'articles#index', section: 'news'
-  get 'news/:slug', to: 'articles#show'
-  get 'about/:slug', to: 'articles#show'
-  get 'docs/:slug', to: 'articles#show'
+  get "/news.atom", to: "articles#index", format: :atom, section: "news"
+  get "/news.rss",  to: "articles#index", format: :rss, section: "news"
+  get "/:section/:slug", to: "articles#show", as: :article,
+    constraints: { section: /(news|about|docs)/ }
 
   # Redirects for backwards compatibility
   get '/about', to: redirect('/about/xronos')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,15 +1,7 @@
 # This file should contain all the record creation needed to seed the database with its default values.
-#
-# Radiocarbon seed data is a random sample from p3k14c v1.0.0
-# <https://core.tdar.org/dataset/459164/p3k14c>
-#
-
 require 'factory_bot'
-require 'open-uri'
-require 'csv'
 
-FactoryBot.create(:user, :admin)
-
-load Rails.root.join("db/seeds/functional_classifications.rb")
+# Load all files in db/seeds/
+Dir[Rails.root.join("db/seeds/**/*.rb")].sort.each { |f| require f }
 
 FactoryBot.create_list(:c14, 100)

--- a/db/seeds/functional_classifications.rb
+++ b/db/seeds/functional_classifications.rb
@@ -16,3 +16,5 @@ functional_categories.each do |name, description|
     category.save!
   end
 end
+
+puts "Seeded functional classification categories: #{functional_categories.map do |c| c.first end}"

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -1,0 +1,17 @@
+admin_email = ENV["ADMIN_USER_EMAIL"]
+
+admin = User.find_or_initialize_by(email: admin_email)
+
+admin.assign_attributes(
+  password: ENV["ADMIN_USER_PASSWORD"],
+  password_confirmation: ENV["ADMIN_USER_PASSWORD"],
+  admin: true,
+  passphrase: ENV["REGISTRATION_PASSPHRASE"]
+)
+
+# Ensure profile exists
+admin.build_user_profile unless admin.user_profile
+
+admin.save!
+
+puts "Seeded default admin user: #{admin.id} <#{admin.email}>"

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class ArticlesControllerTest < ActionDispatch::IntegrationTest
+  # --- Atom and RSS feeds ---
+
+  test "atom feed returns success and correct content type" do
+    get news_url(format: :atom)
+
+    assert_response :success
+    assert_equal "application/atom+xml", response.media_type
+  end
+
+  test "rss feed returns success and correct content type" do
+    get news_url(format: :rss)
+
+    assert_response :success
+    assert_equal "application/rss+xml", response.media_type
+  end
+
+  test "feed includes only published articles" do
+    published = create(:article, :published, title: "Published")
+    create(:article, :scheduled, title: "Scheduled")
+    create(:article, :draft, title: "Draft")
+
+    get news_url(format: :atom)
+
+    body = response.body
+
+    assert_includes body, "Published"
+    assert_not_includes body, "Scheduled"
+    assert_not_includes body, "Draft"
+  end
+
+  test "feed orders articles by published_at descending" do
+    older = create(:article, :published, title: "Older", published_at: 2.days.ago)
+    newer = create(:article, :published, title: "Newer", published_at: 1.hour.ago)
+
+    get news_url(format: :atom)
+
+    titles = response.body.scan(/<title>(.*?)<\/title>/).flatten
+
+    assert titles.index("Newer") < titles.index("Older")
+  end
+
+  test "feed includes correct article URLs" do
+    article = create(:article, :published, section: "news", slug: "test-article")
+
+    get news_url(format: :atom)
+
+    expected_url = article_url(section: "news", slug: "test-article")
+
+    assert_includes response.body, expected_url
+  end
+
+  test "atom feed includes required elements" do
+    create(:article, :published)
+
+    get news_url(format: :atom)
+
+    body = response.body
+
+    assert_includes body, "<feed"
+    assert_includes body, "<entry>"
+    assert_includes body, "<id>"
+    assert_includes body, "<updated>"
+  end
+
+  test "rss feed includes required elements" do
+    create(:article, :published)
+
+    get news_url(format: :rss)
+
+    body = response.body
+
+    assert_includes body, "<rss"
+    assert_includes body, "<channel>"
+    assert_includes body, "<item>"
+    assert_includes body, "<guid>"
+  end
+
+  test "feed includes author name from user profile" do
+    user = create(:user)
+    user.user_profile.update!(full_name: "Jane Doe")
+
+    create(:article, :published, user: user)
+
+    get news_url(format: :atom)
+
+    assert_includes response.body, "Jane Doe"
+  end
+
+  test "atom feed includes pagination links" do
+    create_list(:article, 25, :published)
+
+    get news_url(format: :atom)
+
+    assert_includes response.body, 'rel="self"'
+    assert_includes response.body, 'rel="next"'
+  end
+
+end

--- a/test/factories/articles.rb
+++ b/test/factories/articles.rb
@@ -1,0 +1,100 @@
+# == Schema Information
+#
+# Table name: articles
+# Database name: primary
+#
+#  id                 :bigint           not null, primary key
+#  body               :text
+#  publish            :boolean          default(FALSE)
+#  published_at       :datetime
+#  section            :integer          not null
+#  slug               :string
+#  splash_attribution :string
+#  title              :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :bigint
+#
+# Indexes
+#
+#  index_articles_on_section  (section)
+#  index_articles_on_slug     (slug) UNIQUE
+#  index_articles_on_user_id  (user_id)
+#
+FactoryBot.define do
+  factory :article do
+    section { "news" }
+
+    title { Faker::Lorem.sentence(word_count: 5) }
+
+    body do
+      Faker::Lorem.paragraphs(number: 2).join("\n\n")
+    end
+
+    sequence(:slug) { |n| "article-#{n}" }
+
+    association :user
+
+    publish { false }
+    published_at { nil }
+
+    trait :about do
+      section { "about" }
+      title { "About #{Faker::Lorem.unique.word.capitalize}" }
+      body do
+        Faker::Lorem.paragraphs(number: 4).join("\n\n")
+      end
+
+      sequence(:slug) { |n| "about-page-#{n}" }
+    end
+
+    trait :news do
+      section { "news" }
+    end
+
+    trait :draft do
+      publish { false }
+      published_at { nil }
+    end
+
+    trait :published do
+      publish { true }
+      published_at { Time.zone.now - rand(1..7).days }
+    end
+
+    trait :recently_published do
+      publish { true }
+      published_at { Time.zone.now - rand(1..24).hours }
+    end
+
+    trait :old_published do
+      publish { true }
+      published_at { Time.zone.now - rand(3..12).months }
+    end
+
+    trait :scheduled do
+      publish { true }
+      published_at { Time.zone.now + rand(1..14).days }
+    end
+
+    trait :long_body do
+      body do
+        Faker::Lorem.paragraphs(number: 8).join("\n\n")
+      end
+    end
+
+    trait :short_body do
+      body { Faker::Lorem.sentence }
+    end
+
+    trait :no_body do
+      body { nil }
+    end
+
+    trait :unpublished_but_dated do
+      publish { false }
+      published_at { Time.zone.now - 1.day }
+    end
+
+  end
+end

--- a/test/factories/articles.rb
+++ b/test/factories/articles.rb
@@ -23,7 +23,7 @@
 #
 FactoryBot.define do
   factory :article do
-    section { "news" }
+    section { :news }
 
     title { Faker::Lorem.sentence(word_count: 5) }
 
@@ -39,7 +39,7 @@ FactoryBot.define do
     published_at { nil }
 
     trait :about do
-      section { "about" }
+      section { :about }
       title { "About #{Faker::Lorem.unique.word.capitalize}" }
       body do
         Faker::Lorem.paragraphs(number: 4).join("\n\n")
@@ -49,7 +49,7 @@ FactoryBot.define do
     end
 
     trait :news do
-      section { "news" }
+      section { :news }
     end
 
     trait :draft do

--- a/test/factories/user_profiles.rb
+++ b/test/factories/user_profiles.rb
@@ -20,12 +20,52 @@
 #
 #  fk_rails_...  (user_id => users.id)
 #
-
 FactoryBot.define do
   factory :user_profile do
-    full_name { Faker::Name.name }
-    orcid { '0000-0002-1825-0097' }
-    public_email { Faker::Internet.email }
-    url { Faker::Internet.url(host: "example.com") }
+    association :user
+
+    full_name { "Test User" }
+
+    sequence(:orcid) { |n| format("0000-0000-0000-%04d", n) }
+
+    public_email { user.email }
+
+    url { "https://example.com/profile" }
+
+    # --- Traits ---
+
+    trait :with_realistic_name do
+      sequence(:full_name) { |n| "User #{n}" }
+    end
+
+    trait :with_orcid do
+      # already default, but kept for clarity/override
+    end
+
+    trait :without_orcid do
+      orcid { nil }
+    end
+
+    trait :custom_email do
+      sequence(:public_email) { |n| "public#{n}@example.com" }
+    end
+
+    trait :no_public_email do
+      public_email { nil }
+    end
+
+    trait :with_url do
+      sequence(:url) { |n| "https://example.com/users/#{n}" }
+    end
+
+    trait :no_url do
+      url { nil }
+    end
+
+    trait :complete do
+      with_realistic_name
+      with_url
+    end
   end
 end
+

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -17,6 +17,29 @@
 #
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
-#
 FactoryBot.define do
+  factory :user do
+    sequence(:email) { |n| "user#{n}@xronos.ch" }
+
+    password { "password" }
+    password_confirmation { "password" }
+
+    admin { false }
+
+    # Only include if validation requires it
+    passphrase { ENV["REGISTRATION_PASSPHRASE"] }
+
+    # --- Traits ---
+
+    trait :admin do
+      admin { true }
+    end
+
+    # --- Associations ---
+
+    after(:build) do |user|
+      user.user_profile ||= build(:user_profile, user: user)
+    end
+  end
 end
+

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -19,20 +19,4 @@
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #
 FactoryBot.define do
-  factory :user do
-    email { "admin@xronos.ch" }
-    password { "Hubsch123123" }
-    password_confirmation { "Hubsch123123" }
-    admin { false }
-    passphrase { ENV["REGISTRATION_PASSPHRASE"] }
-    trait :admin do
-      email { "admin@xronos.ch" }
-      admin { true }
-    end    
-    factory :admin, traits: [:admin]
-
-    after(:build) do |user|
-      user.user_profile = build(:user_profile, user: user)
-    end
-  end
 end

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -1,0 +1,170 @@
+# == Schema Information
+#
+# Table name: articles
+# Database name: primary
+#
+#  id                 :bigint           not null, primary key
+#  body               :text
+#  publish            :boolean          default(FALSE)
+#  published_at       :datetime
+#  section            :integer          not null
+#  slug               :string
+#  splash_attribution :string
+#  title              :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :bigint
+#
+# Indexes
+#
+#  index_articles_on_section  (section)
+#  index_articles_on_slug     (slug) UNIQUE
+#  index_articles_on_user_id  (user_id)
+#
+require "test_helper"
+
+class ArticleTest < ActiveSupport::TestCase
+
+  # --- Factory baseline ---
+
+  test "factory builds a valid draft article" do
+    article = build(:article)
+
+    assert article.valid?
+    assert_not article.publish
+    assert_nil article.published_at
+  end
+
+  # --- Publication states ---
+
+  test "draft has no publication date" do
+    article = build(:article, :draft)
+
+    assert_not article.publish
+    assert_nil article.published_at
+  end
+
+  test "published article has past published_at" do
+    article = build(:article, :published)
+
+    assert article.publish
+    assert article.published_at.present?
+    assert_operator article.published_at, :<=, Time.zone.now
+  end
+
+  test "scheduled article has future published_at" do
+    article = build(:article, :scheduled)
+
+    assert article.publish
+    assert article.published_at.present?
+    assert_operator article.published_at, :>, Time.zone.now
+  end
+
+  # --- Draft/published methods ---
+
+  test "published? returns true for published past articles" do
+    article = build(:article, :published)
+
+    assert article.published?
+    assert_not article.scheduled?
+    assert_not article.draft?
+  end
+
+  test "scheduled? returns true for future published articles" do
+    article = build(:article, :scheduled)
+
+    assert article.scheduled?
+    assert_not article.published?
+    assert_not article.draft?
+  end
+
+  test "draft? returns true when publish is false" do
+    article = build(:article, :draft)
+
+    assert article.draft?
+    assert_not article.published?
+    assert_not article.scheduled?
+  end
+
+  test "unpublished article with past date is still draft" do
+    article = build(:article, :unpublished_but_dated)
+
+    assert article.draft?
+    assert_not article.published?
+    assert_not article.scheduled?
+  end
+
+  # --- Sections ---
+
+  test "news article has section news" do
+    article = build(:article, :news)
+    assert_equal "news", article.section
+  end
+
+  test "about article has section about" do
+    article = build(:article, :about)
+    assert_equal "about", article.section
+  end
+
+  # --- Ordering ---
+
+  test "articles can be ordered by published_at" do
+    older = create(:article, :published, published_at: 2.weeks.ago)
+    newer = create(:article, :published, published_at: 1.day.ago)
+
+    assert_operator newer.published_at, :>, older.published_at
+  end
+
+  # --- Scopes ---
+
+  test "published scope returns only current published articles" do
+    published = create(:article, :published)
+    scheduled = create(:article, :scheduled)
+    draft     = create(:article, :draft)
+
+    results = Article.published
+
+    assert_includes results, published
+    assert_not_includes results, scheduled
+    assert_not_includes results, draft
+  end
+
+  test "published scope matches published? predicate" do
+    articles = [
+      create(:article, :published),
+      create(:article, :scheduled),
+      create(:article, :draft)
+    ]
+
+    scope_ids = Article.published.pluck(:id)
+
+    articles.each do |article|
+      if article.published?
+        assert_includes scope_ids, article.id
+      else
+        assert_not_includes scope_ids, article.id
+      end
+    end
+  end
+
+  test "published scope includes articles published now" do
+    now = Time.zone.now
+
+    article = create(:article, publish: true, published_at: now)
+
+    assert_includes Article.published, article
+  end
+
+  test "published scope excludes future articles" do
+    article = create(:article, publish: true, published_at: 1.day.from_now)
+
+    assert_not_includes Article.published, article
+  end
+
+  test "published scope excludes drafts with past date" do
+    article = create(:article, publish: false, published_at: 1.day.ago)
+
+    assert_not_includes Article.published, article
+  end
+
+end


### PR DESCRIPTION
Adds Atom and RSS feeds for news posts (#395) along with tests for articles.

Getting a functional test factory for articles required changing the way we seed the admin user (moving out of the test factory). This means that **a new environment variable is now required when setting up a new database**: `ADMIN_USER_PASSWORD`. I have updated the README accordingly. This only affects development and test environments; no changes are needed in production.