### PR TITLE
Eliminate warnings on server start

### DIFF
--- a/app/assets/stylesheets/_bootstrap_config.scss
+++ b/app/assets/stylesheets/_bootstrap_config.scss
@@ -1,0 +1,29 @@
+$primary:    #3C3B39;
+$secondary:  #AE8847;
+$success:    #696B46;
+$info:       #D1D7DB;
+$warning:    #FABD2F;
+$danger:     #A8462D;
+$light:      #F4F5F6;
+$dark:       #1D1D1D;
+
+$font-family-sans-serif:
+	Inter,
+	Helvetica Neue,
+	Helvetica,
+	Nimbus Sans,
+	FreeSans,
+	Arial,
+	Arimo,
+	Liberation Sans,
+	sans-serif;
+
+$headings-font-family: "Raleway", $font-family-sans-serif;
+
+$font-family-monospace: "Fira Mono", SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+$enable-rounded: false;
+$enable-shadows: true;
+
+// More lines please
+$card-border-color: $dark;
+$card-cap-bg: none;

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,48 +1,36 @@
 // Custom Bootstrap variables
-$primary:    #3C3B39;
-$secondary:  #AE8847;
-$success:    #696B46;
-$info:       #D1D7DB;
-$warning:    #FABD2F;
-$danger:     #A8462D;
-$light:      #F4F5F6;
-$dark:       #1D1D1D;
-
-$font-family-sans-serif:
-	Inter,
-	Helvetica Neue, 
-	Helvetica, 
-	Nimbus Sans,
-	FreeSans,
-	Arial, 
-	Arimo,
-	Liberation Sans,
-	sans-serif;
-
-$headings-font-family: "Raleway", $font-family-sans-serif;
-
-$font-family-monospace: "Fira Mono", SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-$enable-rounded: false;
-$enable-shadows: true;
-
-// More lines please
-$card-border-color: $dark;
-$card-cap-bg: none;
+@use 'bootstrap_config' as *;
 
 // Bootstrap
-@import 'bootstrap/scss/bootstrap';
-@import 'bootstrap-icons/font/bootstrap-icons';
+@use 'bootstrap/scss/bootstrap' with (
+	$primary: $primary,
+	$secondary: $secondary,
+	$success: $success,
+	$info: $info,
+	$warning: $warning,
+	$danger: $danger,
+	$light: $light,
+	$dark: $dark,
+	$font-family-sans-serif: $font-family-sans-serif,
+	$headings-font-family: $headings-font-family,
+	$font-family-monospace: $font-family-monospace,
+	$enable-rounded: $enable-rounded,
+	$enable-shadows: $enable-shadows,
+	$card-border-color: $card-border-color,
+	$card-cap-bg: $card-cap-bg
+);
+@use 'bootstrap-icons/font/bootstrap-icons' as *;
 
 // Library stylesheets (moved from JavaScript CSS imports)
-@import 'nouislider/dist/nouislider';
-@import 'tom-select/dist/css/tom-select.bootstrap5.min';
-@import 'easymde/dist/easymde.min';
+@use 'nouislider/dist/nouislider';
+@use 'tom-select/dist/css/tom-select.bootstrap5.min';
+@use 'easymde/dist/easymde.min';
 
 // Application
-@import "components";
-@import "forms";
-@import "leaflet";
-@import "layout";
-@import "slider";
-@import "typography";
-@import "fonts";
+@use 'components';
+@use 'forms';
+@use 'leaflet';
+@use 'layout';
+@use 'slider';
+@use 'typography';
+@use 'fonts';

--- a/app/assets/stylesheets/slider.scss
+++ b/app/assets/stylesheets/slider.scss
@@ -1,3 +1,5 @@
+@use 'bootstrap/scss/bootstrap' as *;
+
 .noUi-connect {
 	background: $primary !important;
 }

--- a/app/assets/stylesheets/typography.scss
+++ b/app/assets/stylesheets/typography.scss
@@ -1,3 +1,5 @@
+@use 'bootstrap/scss/bootstrap' as *;
+
 .dl-inline dt:before {
 	content: "";
 	display: block;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	},
 	"scripts": {
 		"build": "esbuild app/javascript/*.* --bundle --minify --sourcemap --outdir=app/assets/builds --public-path=/assets --loader:.png=file",
-		"build:css:compile": "sass --style=compressed ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/frontend.css --no-source-map --load-path=node_modules",
+		"build:css:compile": "sass --quiet-deps --style=compressed ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/frontend.css --no-source-map --load-path=node_modules",
 		"build:css:prefix": "postcss ./app/assets/builds/frontend.css --use=autoprefixer --output=./app/assets/builds/frontend.css",
 		"build:css": "yarn build:css:compile && yarn build:css:prefix",
 		"watch:css": "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \"yarn build:css\""

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"build:css:compile": "sass --quiet-deps --style=compressed ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/frontend.css --no-source-map --load-path=node_modules",
 		"build:css:prefix": "postcss ./app/assets/builds/frontend.css --use=autoprefixer --output=./app/assets/builds/frontend.css",
 		"build:css": "yarn build:css:compile && yarn build:css:prefix",
-		"watch:css": "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \"yarn build:css\""
+		"watch:css": "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \"yarn build:css\"",
+		"postinstall": "update-browserslist-db"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,9 +401,9 @@ browserslist@^4.23.3:
     update-browserslist-db "^1.1.1"
 
 caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001669:
-  version "1.0.30001760"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz"
-  integrity sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==
+  version "1.0.30001799"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz"
+  integrity sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==
 
 chokidar@^3.3.0, chokidar@^3.5.2:
   version "3.6.0"


### PR DESCRIPTION
- For the SASS deprecation warnings about `@import` used in our own code, replaces it with `@use`
- For the SASS deprecation warnings about `@import` used by Bootstrap, adds `--quiet-deps` to the package build to silence the warnings (there's generally nothing we can do about warnings in dependencies)
- For the warning about an out of data browserlist, adds a postinstall hook to update it on ever `yarn install`