### PR TITLE
Maintain test workflow configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage/coverage.xml') != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           files: coverage/coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,10 @@ jobs:
           fi
 
       - name: Upload coverage to Codecov
+        if: >
+          always() &&
+          hashFiles('coverage/coverage.xml') != '' &&
+          (github.event_name == 'pull_request' || github.ref == 'refs/heads/master')
         uses: codecov/codecov-action@v7
         with:
           files: coverage/coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,13 @@ jobs:
       - name: Run system test suite
         run: bin/rails test:system
 
+      - name: Inspect coverage report
+        if: always() && hashFiles('coverage/coverage.xml') != ''
+        shell: bash
+        run: |
+          ls -lh coverage/coverage.xml
+          head -n 5 coverage/coverage.xml
+
       - name: Determine Codecov parent commit
         id: codecov_parent
         shell: bash
@@ -106,4 +113,6 @@ jobs:
           override_branch: ${{ github.head_ref || github.ref_name }}
           override_commit: ${{ github.event.pull_request.head.sha || github.sha }}
           override_pr: ${{ github.event.pull_request.number }}
+          override_build: ${{ github.run_id }}
+          override_build_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           commit_parent: ${{ steps.codecov_parent.outputs.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,8 +85,11 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "Using pull request base SHA: ${{ github.event.pull_request.base.sha }}"
           else
-            echo "sha=$(git rev-parse HEAD^)" >> "$GITHUB_OUTPUT"
+            parent_sha="$(git rev-parse HEAD^)"
+            echo "sha=${parent_sha}" >> "$GITHUB_OUTPUT"
+            echo "Using first parent SHA: ${parent_sha}"
           fi
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,6 @@ jobs:
           --health-retries 5
 
     env:
-      # Opt JavaScript-based GitHub Actions into Node.js 24 while keeping
-      # the project runtime below unchanged.
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       RAILS_ENV: test
@@ -67,7 +65,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libboost-all-dev
+          sudo apt-get install -y build-essential libboost-program-options-dev
 
       - name: Build calibrator
         run: bin/build_calibrator
@@ -81,11 +79,28 @@ jobs:
       - name: Run system test suite
         run: bin/rails test:system
 
+      - name: Determine Codecov parent commit
+        id: codecov_parent
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$(git rev-parse HEAD^)" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload coverage to Codecov
-        if: always() && hashFiles('coverage/coverage.xml') != ''
+        if: >
+          always() &&
+          hashFiles('coverage/coverage.xml') != '' &&
+          (github.event_name == 'pull_request' || github.ref == 'refs/heads/master')
         uses: codecov/codecov-action@v7
         with:
           files: coverage/coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
+          override_branch: ${{ github.head_ref || github.ref_name }}
+          override_commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          override_pr: ${{ github.event.pull_request.number }}
+          commit_parent: ${{ steps.codecov_parent.outputs.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,11 +73,14 @@ jobs:
       - name: Prepare database
         run: bin/rails db:prepare
 
+      - name: Clear previous coverage
+        run: rm -rf coverage
+
       - name: Run test suite
-        run: bin/rails test
+        run: SIMPLECOV_COMMAND_NAME=rails-tests bin/rails test
 
       - name: Run system test suite
-        run: bin/rails test:system
+        run: SIMPLECOV_COMMAND_NAME=system-tests bin/rails test:system
 
       - name: Inspect coverage report
         if: always() && hashFiles('coverage/coverage.xml') != ''
@@ -85,6 +88,7 @@ jobs:
         run: |
           ls -lh coverage/coverage.xml
           head -n 5 coverage/coverage.xml
+          ls -lah coverage || true
 
       - name: Determine Codecov parent commit
         id: codecov_parent

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -21,12 +22,16 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: xronos
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres -d xronos"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
 
     env:
+      # Opt JavaScript-based GitHub Actions into Node.js 24 while keeping
+      # the project runtime below unchanged.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
       RAILS_ENV: test
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -41,6 +46,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -75,8 +82,10 @@ jobs:
         run: bin/rails test:system
 
       - name: Upload coverage to Codecov
+        if: always() && hashFiles('coverage/coverage.xml') != ''
         uses: codecov/codecov-action@v4
         with:
           files: coverage/coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+          verbose: true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,9 @@ if ENV["COVERAGE"]
   require "simplecov"
   require "simplecov-cobertura"
 
+  SimpleCov.command_name ENV.fetch("SIMPLECOV_COMMAND_NAME", "rails-tests")
+  SimpleCov.merge_timeout 3600
+
   SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
     SimpleCov::Formatter::CoberturaFormatter


### PR DESCRIPTION
This maintenance PR updates the test workflow and Codecov coverage upload configuration.

The original problem was that Codecov uploads succeeded, but Codecov could no longer compute PR/master comparisons reliably, showing states such as “Missing Base Commit”, “Missing Comparison”, or “Missing Head Report”. Updating the Codecov action alone was not sufficient.

Changes:

- run tests on `pull_request` as well as `push`
- checkout full git history with `fetch-depth: 0`
- align the checked-out commit with the commit SHA reported to Codecov
- update Codecov upload to `codecov/codecov-action@v7`
- pass explicit Codecov metadata for branch, commit, PR, parent/base commit, build ID, and build URL
- restrict Codecov uploads to PR runs and `master`
- opt JavaScript-based GitHub Actions into Node.js 24
- use distinct SimpleCov command names for regular Rails tests and system tests so their coverage can be merged into a single report

With the current configuration, Codecov again recognises the PR comparison, e.g. “this commit compared to master base”. Since this PR changes workflow/test configuration rather than covered application files, Codecov reports that no covered files changed, which is expected.

The remaining Node.js 20 warning appears to come from current action runtime metadata and is not blocking.