### PR TITLE
Model supersession as assocation-as-state

### DIFF
--- a/app/models/c14.rb
+++ b/app/models/c14.rb
@@ -20,7 +20,6 @@
 #  lab_identifier :string
 #  method         :string
 #  std            :integer
-#  superseded_by  :integer
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  c14_lab_id     :bigint
@@ -32,7 +31,6 @@
 #  index_c14s_on_lab_identifier  (lab_identifier)
 #  index_c14s_on_method          (method)
 #  index_c14s_on_sample_id       (sample_id)
-#  index_c14s_on_superseded_by   (superseded_by)
 #
 
 class C14 < ApplicationRecord

--- a/app/models/concerns/duplicable.rb
+++ b/app/models/concerns/duplicable.rb
@@ -56,13 +56,13 @@ module Duplicable
 
     def merge_duplicates(duplicates)
       original = duplicates.first
-      dupes = duplicates.drop(1)
-      dupes.each do |dupe| 
-        dupe.superseded_by = original.id # TODO: why .id here??
-        dupe.revision_comment = "Merged with #{original.model_name.singular}:#{original.id}"
-        dupe.save!
+      duplicates.drop(1).each do |dupe|
+        dupe.supersede!(
+          original,
+          "Merged with #{original.model_name.singular}:#{original.id}"
+        )
       end
-      return original
+      original
     end
 
   end

--- a/app/models/concerns/supersedable.rb
+++ b/app/models/concerns/supersedable.rb
@@ -2,7 +2,7 @@ module Supersedable
   # Reflections excluded from reassignment: `versions` (paper_trail metadata
   # must not be rewritten) and `pg_search_document` (managed separately by
   # pg_search).
-  EXCLUDED_REFLECTIONS = %w[versions pg_search_document].freeze
+  EXCLUDED_REFLECTIONS = %w[versions pg_search_document supersession supersession_events].freeze
 
   CHILD_REFLECTIONS = [
     ActiveRecord::Reflection::HasOneReflection,
@@ -12,82 +12,144 @@ module Supersedable
 
   extend ActiveSupport::Concern
 
-  included do # instance methods # rubocop:disable Metrics/BlockLength
-    default_scope { where(superseded_by: nil) }
+  included do # instance methods
+    has_one  :supersession, as: :superseded, dependent: :destroy
+    has_many :supersession_events, as: :superseded
 
-    def supersedable?
-      true
+    # Default scope: hide records that have a current Supersession row.
+    # The unique index on supersessions.superseded_id makes this an
+    # index-only subquery.
+    default_scope { where.not(id: Supersession.select(:superseded_id)) }
+  end
+
+  def supersedable?
+    true
+  end
+
+  def superseded?
+    supersession.present?
+  end
+
+  def not_superseded?
+    !superseded?
+  end
+
+  # Walks the supersession graph to the current canonical,
+  # non-superseded record. Self is the base case. The unique index on
+  # supersessions.superseded_id guarantees there is at most one
+  # Supersession row per record, so this terminates.
+  def ultimately_superseded_by
+    return self unless superseded?
+
+    supersession.superseded_by.ultimately_superseded_by
+  end
+
+  # Append-only event log view of this record's supersession history.
+  def merge_history
+    supersession_events.order(:created_at)
+  end
+
+  # Make `self` superseded by `canonical`. Atomic: writes the
+  # SupersessionEvent row and the Supersession row in one transaction,
+  # and reassigns all eligible child associations to the canonical.
+  #
+  # When `self` is being merged, any other records that are currently
+  # superseded by `self` are re-pointed to the new canonical. This
+  # preserves the invariant that every Supersession row points at a
+  # currently-canonical record.
+  #
+  # Preconditions:
+  #   - `canonical` must not be `self`
+  #   - `self` must not already be superseded
+  #   - `canonical` must currently be canonical (not superseded)
+  # The unique index on supersessions.superseded_id is the DB-level
+  # safety net.
+  def supersede!(canonical, revision_comment = nil) # rubocop:disable Metrics/MethodLength
+    raise ArgumentError, "Cannot supersede a record by itself" if canonical == self
+    raise 'Record is already superseded' if superseded?
+    raise 'Cannot supersede into a superseded record' if canonical.superseded?
+
+    transaction do
+      re_point_existing_supersessions_to(canonical)
+
+      supersession_state = Supersession.create!(superseded: self, superseded_by: canonical)
+      self.supersession = supersession_state
+      SupersessionEvent.create!(
+        event_type: 'supersede',
+        superseded: self,
+        superseded_by: canonical,
+        comment: revision_comment
+      )
+      reassign_associations!(revision_comment, supersession_state)
     end
+  end
 
-    def superseded?
-      superseded_by.present?
+  # Restore `self` to canonical. Removes the current Supersession row
+  # and appends a 'restore' event. The re-pointing case (where the
+  # original target was itself superseded after the original merge) is
+  # handled inside `supersede!` at the time the target was superseded,
+  # not here, so this method stays simple.
+  def restore! # rubocop:disable Metrics/MethodLength
+    raise 'Not currently superseded' unless superseded?
+
+    old_target = supersession.superseded_by
+    transaction do
+      supersession.destroy!
+      SupersessionEvent.create!(
+        event_type: 'restore',
+        superseded: self,
+        superseded_by: old_target
+      )
     end
-
-    def not_superseded?
-      superseded_by.blank?
-    end
-
-    # Follows the superseded_by chain to the canonical (non-superseded)
-    # record. Bypasses the default scope by using unscoped.
-    def ultimately_superseded_by
-      if superseded_by.present?
-        self.class.unscoped.find(superseded_by).ultimately_superseded_by
-      else
-        self.class.find(id)
-      end
-    end
-
-    # Reassign all eligible child associations to this record's canonical
-    # target (its `superseded_by`). Caller is responsible for setting
-    # `superseded_by` first.
-    def reassign_associations(revision_comment = nil)
-      raise 'Attempt to reassign associations of record that is not superseded.' unless superseded?
-
-      self.class.supersedable_associations.each_value do |reflection|
-        reassign_one(reflection, revision_comment)
-      end
-
-      true
-    end
-
-    private
-
-    def reassign_one(reflection, revision_comment)
-      if reflection.is_a?(ActiveRecord::Reflection::HasAndBelongsToManyReflection)
-        reassign_many_to_many(reflection, revision_comment)
-      else
-        reassign_one_to_many(reflection, revision_comment)
-      end
-    end
-
-    def reassign_one_to_many(reflection, revision_comment)
-      revision_comment ||= default_revision_comment
-      send(reflection.name).each do |child|
-        child.write_attribute(reflection.foreign_key, superseded_by)
-        child.revision_comment = revision_comment if child.respond_to?(:revision_comment=)
-        child.save!
-      end
-    end
-
-    # HABTM reassignment is not implemented yet; would require
-    # building/destroying join rows.
-    def reassign_many_to_many(_reflection, _revision_comment)
-      # TODO
-    end
-
-    def default_revision_comment
-      "#{self.class.model_name.singular}:#{id} has been superseded by " \
-        "#{self.class.model_name.singular}:#{superseded_by}"
-    end
+  ensure
+    # Clear the in-memory association cache so a follow-up
+    # supersede!() doesn't see a stale (now-destroyed) row.
+    association(:supersession).reset
   end
 
   class_methods do
     # Returns the set of reflections whose child records should be
-    # reassigned when a record is merged into its canonical target.
+    # reassigned when a record is superseded. Excludes through-reflections
+    # (those are navigated via the underlying has_many), HABTM
+    # (TODO), and the supersession bookkeeping itself.
     def supersedable_associations
       reflections
         .reject { |k, _v| EXCLUDED_REFLECTIONS.include?(k) }
-        .select { |_k, v| CHILD_REFLECTIONS.any? { |klass| v.is_a?(klass) } }
+        .select { |_k, v| direct_child_reflection?(v) }
     end
+
+    private
+
+    def direct_child_reflection?(reflection)
+      return false if reflection.is_a?(ActiveRecord::Reflection::ThroughReflection)
+      return false if reflection.is_a?(ActiveRecord::Reflection::HasAndBelongsToManyReflection)
+
+      CHILD_REFLECTIONS.any? { |klass| reflection.is_a?(klass) }
+    end
+  end
+
+  private # rubocop:disable Lint/UselessAccessModifier
+
+  def reassign_associations!(revision_comment, supersession_state = nil)
+    supersession_state ||= supersession
+    target_id = supersession_state.superseded_by_id
+    self.class.supersedable_associations.each_value do |reflection|
+      send(reflection.name).each do |child|
+        child.write_attribute(reflection.foreign_key, target_id)
+        child.revision_comment = revision_comment if child.respond_to?(:revision_comment=)
+        child.save!
+      end
+    end
+  end
+
+  def re_point_existing_supersessions_to(canonical)
+    Supersession
+      .where(superseded_by: self)
+      .where.not(superseded: canonical)
+      .update_all(
+        superseded_by_type: canonical.class.name,
+        superseded_by_id: canonical.id,
+        updated_at: Time.current
+      )
   end
 end

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -3,17 +3,15 @@
 # Table name: references
 # Database name: primary
 #
-#  id            :bigint           not null, primary key
-#  bibtex        :text
-#  short_ref     :string
-#  superseded_by :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id         :bigint           not null, primary key
+#  bibtex     :text
+#  short_ref  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 # Indexes
 #
-#  index_references_on_short_ref      (short_ref)
-#  index_references_on_superseded_by  (superseded_by)
+#  index_references_on_short_ref  (short_ref)
 #
 
 class Reference < ApplicationRecord

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -3,14 +3,13 @@
 # Table name: sites
 # Database name: primary
 #
-#  id            :bigint           not null, primary key
-#  country_code  :string
-#  lat           :decimal(, )
-#  lng           :decimal(, )
-#  name          :string
-#  superseded_by :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id           :bigint           not null, primary key
+#  country_code :string
+#  lat          :decimal(, )
+#  lng          :decimal(, )
+#  name         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 # Indexes
 #

--- a/app/models/supersession.rb
+++ b/app/models/supersession.rb
@@ -1,0 +1,46 @@
+class Supersession < ApplicationRecord
+  belongs_to :superseded,    polymorphic: true
+  belongs_to :superseded_by, polymorphic: true
+
+  # Cache of currently-active supersessions. SupersessionEvent is the
+  # source of truth. If these two disagree, the event log wins; call
+  # `Supersession.rebuild_from_events!` to restore this table from it.
+  #
+  # Used as a fast index for the Supersedable default scope: a record
+  # is "superseded" iff a Supersession row exists for it. The unique
+  # index on (superseded_type, superseded_id) enforces the invariant
+  # "at most one current supersession per record" at the DB level.
+
+  # Rebuild the cache from the event log. Walks events in order,
+  # maintaining an in-memory {superseded_record => canonical_record}
+  # map, and inserts/deletes Supersession rows to match. The
+  # invariant: after this method returns, the set of Supersession rows
+  # equals the set of records that have a 'supersede' event with no
+  # later 'restore' event.
+  def self.rebuild_from_events! # rubocop:disable Metrics/MethodLength
+    transaction do
+      delete_all
+
+      active = {}
+
+      SupersessionEvent.order(:created_at, :id).each do |event|
+        key = [event.superseded_type, event.superseded_id]
+        case event.event_type
+        when 'supersede'
+          active[key] = [event.superseded_by_type, event.superseded_by_id]
+        when 'restore'
+          active.delete(key)
+        end
+      end
+
+      active.each do |(stype, sid), (btype, bid)|
+        create!(
+          superseded_type: stype,
+          superseded_id: sid,
+          superseded_by_type: btype,
+          superseded_by_id: bid
+        )
+      end
+    end
+  end
+end

--- a/app/models/supersession_event.rb
+++ b/app/models/supersession_event.rb
@@ -1,0 +1,26 @@
+class SupersessionEvent < ApplicationRecord
+  belongs_to :superseded,    polymorphic: true
+  belongs_to :superseded_by, polymorphic: true
+
+  EVENT_TYPES = %w[supersede restore].freeze
+  validates :event_type, inclusion: { in: EVENT_TYPES }
+  validate  :not_self_supersession
+
+  # Append-only by contract; enforced at the application layer.
+  before_update  :prevent_mutation
+  before_destroy :prevent_mutation
+
+  private
+
+  def not_self_supersession
+    return unless superseded_type == superseded_by_type &&
+                  superseded_id   == superseded_by_id
+
+    errors.add(:superseded_by, 'cannot be the same as superseded')
+  end
+
+  def prevent_mutation
+    raise ActiveRecord::ReadOnlyRecord,
+          'SupersessionEvent is append-only; create a new event instead'
+  end
+end

--- a/app/models/typo.rb
+++ b/app/models/typo.rb
@@ -7,7 +7,6 @@
 #  approx_end_time   :integer
 #  approx_start_time :integer
 #  name              :string
-#  superseded_by     :integer
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  parent_id         :integer
@@ -15,9 +14,8 @@
 #
 # Indexes
 #
-#  index_typos_on_name           (name)
-#  index_typos_on_sample_id      (sample_id)
-#  index_typos_on_superseded_by  (superseded_by)
+#  index_typos_on_name       (name)
+#  index_typos_on_sample_id  (sample_id)
 #
 
 class Typo < ApplicationRecord

--- a/db/migrate/20260702150000_create_supersessions.rb
+++ b/db/migrate/20260702150000_create_supersessions.rb
@@ -1,0 +1,15 @@
+class CreateSupersessions < ActiveRecord::Migration[8.0]
+  def change # rubocop:disable Metrics/MethodLength
+    create_table :supersessions do |t|
+      t.references :superseded,
+                  polymorphic: true,
+                  null: false,
+                  index: {
+                    unique: true,
+                    name: 'index_supersessions_unique_superseded'
+                  }
+      t.references :superseded_by, polymorphic: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260702150001_create_supersession_events.rb
+++ b/db/migrate/20260702150001_create_supersession_events.rb
@@ -1,0 +1,29 @@
+class CreateSupersessionEvents < ActiveRecord::Migration[8.0]
+  def change # rubocop:disable Metrics/MethodLength
+    create_table :supersession_events do |t|
+      t.string :event_type, null: false
+      t.references :superseded, polymorphic: true, null: false
+      t.references :superseded_by, polymorphic: true, null: false
+      t.text :comment
+      t.timestamps
+    end
+
+    # Replace the default polymorphic indexes with composite
+    # (polymorphic + created_at) indexes that serve the
+    # merge_history and "what was ever merged into X" queries.
+    remove_index :supersession_events, name: 'index_supersession_events_on_superseded'
+    remove_index :supersession_events, name: 'index_supersession_events_on_superseded_by'
+
+    add_index :supersession_events,
+              %i[superseded_type superseded_id created_at],
+              name: 'index_supersession_events_on_superseded'
+
+    add_index :supersession_events,
+              %i[superseded_by_type superseded_by_id created_at],
+              name: 'index_supersession_events_on_superseded_by'
+
+    add_index :supersession_events,
+              %i[event_type created_at],
+              name: 'index_supersession_events_on_event_type'
+  end
+end

--- a/db/migrate/20260702150002_drop_superseded_by_columns.rb
+++ b/db/migrate/20260702150002_drop_superseded_by_columns.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Drops the superseded_by integer columns and their indexes from
+# sites, c14s, references, and typos. The state previously encoded in
+# these columns is now held by the Supersession / SupersessionEvent
+# tables introduced in the prior migrations.
+#
+# Reversible: re-adds the column (no data restoration).
+class DropSupersededByColumns < ActiveRecord::Migration[8.0]
+  def up
+    remove_index :c14s, :superseded_by if index_exists?(:c14s, :superseded_by)
+    remove_index :references, :superseded_by if index_exists?(:references, :superseded_by)
+    remove_index :typos, :superseded_by if index_exists?(:typos, :superseded_by)
+
+    remove_column :c14s, :superseded_by
+    remove_column :references, :superseded_by
+    remove_column :sites, :superseded_by
+    remove_column :typos, :superseded_by
+  end
+
+  def down
+    add_column :sites, :superseded_by, :integer
+    add_column :c14s, :superseded_by, :integer
+    add_column :references, :superseded_by, :integer
+    add_column :typos, :superseded_by, :integer
+
+    add_index :c14s, :superseded_by
+    add_index :references, :superseded_by
+    add_index :typos, :superseded_by
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_02_140000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_02_150002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -83,12 +83,10 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_02_140000) do
     t.bigint "sample_id"
     t.string "lab_identifier"
     t.float "delta_15n"
-    t.integer "superseded_by"
     t.index ["c14_lab_id"], name: "index_c14s_on_c14_lab_id"
     t.index ["lab_identifier"], name: "index_c14s_on_lab_identifier"
     t.index ["method"], name: "index_c14s_on_method"
     t.index ["sample_id"], name: "index_c14s_on_sample_id"
-    t.index ["superseded_by"], name: "index_c14s_on_superseded_by"
   end
 
   create_table "cals", force: :cascade do |t|
@@ -284,9 +282,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_02_140000) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "short_ref"
-    t.integer "superseded_by"
     t.index ["short_ref"], name: "index_references_on_short_ref"
-    t.index ["superseded_by"], name: "index_references_on_superseded_by"
   end
 
   create_table "samples", force: :cascade do |t|
@@ -347,7 +343,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_02_140000) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "country_code"
-    t.integer "superseded_by"
     t.index ["country_code"], name: "index_sites_on_country_code"
     t.index ["name"], name: "index_sites_on_name"
   end
@@ -367,6 +362,31 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_02_140000) do
     t.index ["reference_id"], name: "index_sources_on_reference_id"
   end
 
+  create_table "supersession_events", force: :cascade do |t|
+    t.string "event_type", null: false
+    t.string "superseded_type", null: false
+    t.bigint "superseded_id", null: false
+    t.string "superseded_by_type", null: false
+    t.bigint "superseded_by_id", null: false
+    t.text "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_type", "created_at"], name: "index_supersession_events_on_event_type"
+    t.index ["superseded_by_type", "superseded_by_id", "created_at"], name: "index_supersession_events_on_superseded_by"
+    t.index ["superseded_type", "superseded_id", "created_at"], name: "index_supersession_events_on_superseded"
+  end
+
+  create_table "supersessions", force: :cascade do |t|
+    t.string "superseded_type", null: false
+    t.bigint "superseded_id", null: false
+    t.string "superseded_by_type", null: false
+    t.bigint "superseded_by_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["superseded_by_type", "superseded_by_id"], name: "index_supersessions_on_superseded_by"
+    t.index ["superseded_type", "superseded_id"], name: "index_supersessions_unique_superseded", unique: true
+  end
+
   create_table "taxons", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: nil, null: false
@@ -384,10 +404,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_02_140000) do
     t.datetime "updated_at", precision: nil, null: false
     t.integer "parent_id"
     t.bigint "sample_id"
-    t.integer "superseded_by"
     t.index ["name"], name: "index_typos_on_name"
     t.index ["sample_id"], name: "index_typos_on_sample_id"
-    t.index ["superseded_by"], name: "index_typos_on_superseded_by"
   end
 
   create_table "user_profiles", force: :cascade do |t|

--- a/test/controllers/c14s_controller_test.rb
+++ b/test/controllers/c14s_controller_test.rb
@@ -8,7 +8,7 @@ class C14sControllerTest < ActionDispatch::IntegrationTest # rubocop:disable Met
     context = create(:context, site: site)
     sample = create(:sample, context: context)
     canonical = create(:c14, sample: sample)
-    superseded = create(:c14, :superseded, superseded_by_c14: canonical, sample: sample)
+    superseded = create(:c14, :superseded_by, canonical: canonical, sample: sample)
 
     get c14_path(superseded)
 
@@ -16,13 +16,16 @@ class C14sControllerTest < ActionDispatch::IntegrationTest # rubocop:disable Met
     assert_equal c14_url(canonical), response.location
   end
 
-  test 'show follows a multi-link superseded chain to the canonical' do
+  test 'show follows a re-pointed chain to the canonical' do
     site = create(:site)
     context = create(:context, site: site)
     sample = create(:sample, context: context)
     canonical = create(:c14, sample: sample)
-    middle = create(:c14, :superseded, superseded_by_c14: canonical, sample: sample)
-    leaf = create(:c14, :superseded, superseded_by_c14: middle, sample: sample)
+    middle = create(:c14, sample: sample)
+    leaf = create(:c14, sample: sample)
+
+    leaf.supersede!(middle)
+    middle.supersede!(canonical)
 
     get c14_path(leaf)
 
@@ -30,7 +33,7 @@ class C14sControllerTest < ActionDispatch::IntegrationTest # rubocop:disable Met
     assert_equal c14_url(canonical), response.location
   end
 
-  test 'downloads a C14 record as MIaaRD JSON' do
+test 'downloads a C14 record as MIaaRD JSON' do
     site = create(
       :site,
       name: 'Test Site',

--- a/test/controllers/references_controller_test.rb
+++ b/test/controllers/references_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class ReferencesControllerTest < ActionDispatch::IntegrationTest
   test 'show redirects to the canonical record when the reference is superseded' do
     canonical = create(:reference)
-    superseded = create(:reference, :superseded, superseded_by_reference: canonical)
+    superseded = create(:reference, :superseded_by, canonical: canonical)
 
     get reference_path(superseded)
 
@@ -13,10 +13,13 @@ class ReferencesControllerTest < ActionDispatch::IntegrationTest
     assert_equal reference_url(canonical), response.location
   end
 
-  test 'show follows a multi-link superseded chain to the canonical' do
+  test 'show follows a re-pointed chain to the canonical' do
     canonical = create(:reference)
-    middle = create(:reference, :superseded, superseded_by_reference: canonical)
-    leaf = create(:reference, :superseded, superseded_by_reference: middle)
+    middle = create(:reference)
+    leaf = create(:reference)
+
+    leaf.supersede!(middle)
+    middle.supersede!(canonical)
 
     get reference_path(leaf)
 

--- a/test/controllers/sites_controller_test.rb
+++ b/test/controllers/sites_controller_test.rb
@@ -5,20 +5,9 @@ require 'test_helper'
 class SitesControllerTest < ActionDispatch::IntegrationTest
   test 'show redirects to the canonical record when the site is superseded' do
     canonical = create(:site)
-    superseded = create(:site, :superseded, superseded_by_site: canonical)
+    superseded = create(:site, :superseded_by, canonical: canonical)
 
     get site_path(superseded)
-
-    assert_response :moved_permanently
-    assert_equal site_url(canonical), response.location
-  end
-
-  test 'show follows a multi-link superseded chain to the canonical' do
-    canonical = create(:site)
-    middle = create(:site, :superseded, superseded_by_site: canonical)
-    leaf = create(:site, :superseded, superseded_by_site: middle)
-
-    get site_path(leaf)
 
     assert_response :moved_permanently
     assert_equal site_url(canonical), response.location

--- a/test/controllers/typos_controller_test.rb
+++ b/test/controllers/typos_controller_test.rb
@@ -18,7 +18,7 @@ class TyposControllerTest < ActionDispatch::IntegrationTest
     site = create(:site)
     sample = create(:sample, context: create(:context, site: site))
     canonical = create(:typo, sample: sample)
-    superseded = create(:typo, :superseded, superseded_by_typo: canonical, sample: sample)
+    superseded = create(:typo, :superseded_by, canonical: canonical, sample: sample)
 
     get typo_path(superseded)
 
@@ -26,12 +26,15 @@ class TyposControllerTest < ActionDispatch::IntegrationTest
     assert_equal site_url(site), response.location
   end
 
-  test 'show follows a multi-link superseded chain to the site of the ultimate canonical' do
+  test 'show follows a re-pointed chain to the site of the ultimate canonical' do
     site = create(:site)
     sample = create(:sample, context: create(:context, site: site))
     canonical = create(:typo, sample: sample)
-    middle = create(:typo, :superseded, superseded_by_typo: canonical, sample: sample)
-    leaf = create(:typo, :superseded, superseded_by_typo: middle, sample: sample)
+    middle = create(:typo, sample: sample)
+    leaf = create(:typo, sample: sample)
+
+    leaf.supersede!(middle)
+    middle.supersede!(canonical)
 
     get typo_path(leaf)
 

--- a/test/factories/c14s.rb
+++ b/test/factories/c14s.rb
@@ -1,35 +1,4 @@
-# == Schema Information
-#
-# Table name: c14s
-# Database name: primary
-#
-#  id             :bigint           not null, primary key
-#  bp             :integer
-#  cal_bp         :integer
-#  cal_std        :integer
-#  delta_15n      :float
-#  delta_c13      :float
-#  delta_c13_std  :float
-#  lab_identifier :string
-#  method         :string
-#  std            :integer
-#  superseded_by  :integer
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  c14_lab_id     :bigint
-#  sample_id      :bigint
-#
-# Indexes
-#
-#  index_c14s_on_c14_lab_id      (c14_lab_id)
-#  index_c14s_on_lab_identifier  (lab_identifier)
-#  index_c14s_on_method          (method)
-#  index_c14s_on_sample_id       (sample_id)
-#  index_c14s_on_superseded_by   (superseded_by)
-#
-
 FactoryBot.define do
-  
   factory :c14 do
     bp { Faker::Number.number(digits: 4) }
     std { Faker::Number.number(digits: 2) }
@@ -39,16 +8,19 @@ FactoryBot.define do
     delta_c13_std { Faker::Number.decimal(l_digits: 2, r_digits: 1) }
     lab_identifier { "#{ Faker::Address.country_code_long }-#{ Faker::Address.building_number }" }
     add_attribute(:method) {Faker::Hacker.noun}
-    
+
     c14_lab
     sample
 
-    trait :superseded do
+    trait :superseded_by do
       transient do
-        superseded_by_c14 { nil }
+        canonical { nil }
       end
 
-      superseded_by { superseded_by_c14&.id }
+      after(:create) do |c14, evaluator|
+        target = evaluator.canonical || create(:c14, sample: c14.sample)
+        create(:supersession, superseded: c14, superseded_by: target)
+      end
     end
 
     trait :with_citations do
@@ -62,5 +34,5 @@ FactoryBot.define do
     end
 
   end
-  
+
 end

--- a/test/factories/references.rb
+++ b/test/factories/references.rb
@@ -1,34 +1,18 @@
-# == Schema Information
-#
-# Table name: references
-# Database name: primary
-#
-#  id            :bigint           not null, primary key
-#  bibtex        :text
-#  short_ref     :string
-#  superseded_by :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#
-# Indexes
-#
-#  index_references_on_short_ref      (short_ref)
-#  index_references_on_superseded_by  (superseded_by)
-#
-
 FactoryBot.define do
-  
   factory :reference do
     bibtex { Faker::Lorem.paragraph }
     short_ref { Faker::Name.last_name + Faker::Number.between(from: 1900, to: 2020).to_s }
 
-    trait :superseded do
+    trait :superseded_by do
       transient do
-        superseded_by_reference { nil }
+        canonical { nil }
       end
 
-      superseded_by { superseded_by_reference&.id }
+      after(:create) do |reference, evaluator|
+        target = evaluator.canonical || create(:reference)
+        create(:supersession, superseded: reference, superseded_by: target)
+      end
     end
   end
-  
+
 end

--- a/test/factories/sites.rb
+++ b/test/factories/sites.rb
@@ -1,23 +1,3 @@
-# == Schema Information
-#
-# Table name: sites
-# Database name: primary
-#
-#  id            :bigint           not null, primary key
-#  country_code  :string
-#  lat           :decimal(, )
-#  lng           :decimal(, )
-#  name          :string
-#  superseded_by :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#
-# Indexes
-#
-#  index_sites_on_country_code  (country_code)
-#  index_sites_on_name          (name)
-#
-
 FactoryBot.define do
   factory :site do
     name { Faker::Verb.unique.base }
@@ -27,12 +7,15 @@ FactoryBot.define do
 
     after(:create) { |site| site.site_types = [create(:site_type)] }
 
-    trait :superseded do
+    trait :superseded_by do
       transient do
-        superseded_by_site { nil }
+        canonical { nil }
       end
 
-      superseded_by { superseded_by_site&.id }
+      after(:create) do |site, evaluator|
+        target = evaluator.canonical || create(:site)
+        create(:supersession, superseded: site, superseded_by: target)
+      end
     end
 
     trait :with_site_names do

--- a/test/factories/supersession_events.rb
+++ b/test/factories/supersession_events.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :supersession_event do
+    event_type    { 'supersede' }
+    superseded    { create(:site) }
+    superseded_by { create(:site) }
+    comment       { nil }
+  end
+
+  factory :supersede_event, parent: :supersession_event, class: 'SupersessionEvent' do
+    event_type { 'supersede' }
+  end
+
+  factory :restore_event, parent: :supersession_event, class: 'SupersessionEvent' do
+    event_type { 'restore' }
+  end
+end

--- a/test/factories/supersessions.rb
+++ b/test/factories/supersessions.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :supersession do
+    superseded    { create(:site) }
+    superseded_by { create(:site) }
+  end
+end

--- a/test/factories/typo.rb
+++ b/test/factories/typo.rb
@@ -4,12 +4,15 @@ FactoryBot.define do
     association :sample
     sequence(:name) { |n| "Typological unit #{n}" }
 
-    trait :superseded do
+    trait :superseded_by do
       transient do
-        superseded_by_typo { nil }
+        canonical { nil }
       end
 
-      superseded_by { superseded_by_typo&.id }
+      after(:create) do |typo, evaluator|
+        target = evaluator.canonical || create(:typo, sample: typo.sample)
+        create(:supersession, superseded: typo, superseded_by: target)
+      end
     end
 
     trait :with_citations do

--- a/test/models/c14_test.rb
+++ b/test/models/c14_test.rb
@@ -15,7 +15,6 @@
 #  lab_identifier :string
 #  method         :string
 #  std            :integer
-#  superseded_by  :integer
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  c14_lab_id     :bigint
@@ -27,7 +26,6 @@
 #  index_c14s_on_lab_identifier  (lab_identifier)
 #  index_c14s_on_method          (method)
 #  index_c14s_on_sample_id       (sample_id)
-#  index_c14s_on_superseded_by   (superseded_by)
 #
 require 'test_helper'
 

--- a/test/models/concerns/supersedable_test.rb
+++ b/test/models/concerns/supersedable_test.rb
@@ -9,17 +9,17 @@ class SupersedableTest < ActiveSupport::TestCase # rubocop:disable Metrics/Class
     assert_not site.superseded?
   end
 
-  test "is superseded when superseded_by is set" do
+  test "is superseded when a Supersession row exists for it" do
     canonical = create(:site)
-    site = create(:site, :superseded, superseded_by_site: canonical)
+    superseded = create(:site, :superseded_by, canonical: canonical)
 
-    assert site.superseded?
-    assert_not site.not_superseded?
+    assert superseded.superseded?
+    assert_not superseded.not_superseded?
   end
 
   test "is hidden from default scope when superseded" do
     canonical = create(:site)
-    superseded = create(:site, :superseded, superseded_by_site: canonical)
+    superseded = create(:site, :superseded_by, canonical: canonical)
 
     assert_includes Site.all, canonical
     assert_not_includes Site.all, superseded
@@ -33,58 +33,107 @@ class SupersedableTest < ActiveSupport::TestCase # rubocop:disable Metrics/Class
 
   test "ultimately_superseded_by follows a single-link chain" do
     canonical = create(:site)
-    superseded = create(:site, :superseded, superseded_by_site: canonical)
+    superseded = create(:site, :superseded_by, canonical: canonical)
 
     assert_equal canonical, superseded.ultimately_superseded_by
   end
 
-  test "ultimately_superseded_by follows a multi-link chain to the canonical" do
-    canonical = create(:site)
-    middle = create(:site, :superseded, superseded_by_site: canonical)
-    leaf = create(:site, :superseded, superseded_by_site: middle)
-
-    assert_equal canonical, leaf.ultimately_superseded_by
+  test "supersede! raises if canonical is self" do
+    site = create(:site)
+    assert_raises(ArgumentError) { site.supersede!(site) }
   end
 
-  test "reassign_associations moves has_many contexts to the canonical record" do
+  test "supersede! raises if self is already superseded" do
     canonical = create(:site)
-    superseded = create(:site, :superseded, superseded_by_site: canonical)
+    superseded = create(:site, :superseded_by, canonical: canonical)
+    another = create(:site)
+
+    assert_raises(RuntimeError) { superseded.supersede!(another) }
+  end
+
+  test "supersede! raises if canonical is itself superseded" do
+    site = create(:site)
+    middle = create(:site)
+    canonical = create(:site, :superseded_by, canonical: middle)
+
+    assert_raises(RuntimeError) { site.supersede!(canonical) }
+  end
+
+  test "supersede! creates a Supersession row and a SupersessionEvent row" do
+    site = create(:site)
+    canonical = create(:site)
+
+    assert_difference -> { Supersession.count } => 1,
+                      -> { SupersessionEvent.count } => 1 do
+      site.supersede!(canonical)
+    end
+  end
+
+  test "supersede! is atomic: failure leaves no cache row and no event row" do
+    site = create(:site)
+    canonical = create(:site)
+    # Force a failure inside the transaction, after the precondition
+    # checks pass. Both the cache and the event log must be
+    # unaffected.
+    SupersessionEvent.stub(:create!, ->(*) { raise ActiveRecord::RecordInvalid }) do
+      assert_no_difference -> { Supersession.count } do
+        assert_no_difference -> { SupersessionEvent.count } do
+          assert_raises(ActiveRecord::RecordInvalid) { site.supersede!(canonical) }
+        end
+      end
+    end
+  end
+
+  test "supersede! re-points existing Supersession(X->self) rows to the new canonical" do
+    a = create(:site)
+    b = create(:site)
+    c = create(:site)
+
+    a.supersede!(b)
+    b.supersede!(c)
+
+    a.reload
+    b.reload
+
+    assert_equal c, a.ultimately_superseded_by
+    assert_equal c, a.supersession.superseded_by
+    assert_equal c, b.ultimately_superseded_by
+  end
+
+  test "supersede! reassigns child associations to the canonical" do
+    canonical = create(:site)
+    superseded = create(:site)
     context = create(:context, site: superseded)
 
-    with_versioning do
-      superseded.reassign_associations("test merge")
-    end
+    superseded.supersede!(canonical, "test merge")
 
     assert_equal canonical, context.reload.site
   end
 
-  test "reassign_associations moves has_many site_names to the canonical record" do
+  test "supersede! reassigns site_names to the canonical" do
     canonical = create(:site)
-    superseded = create(:site, :superseded, superseded_by_site: canonical)
+    superseded = create(:site)
     site_name = create(:site_name, site: superseded)
 
-    with_versioning do
-      superseded.reassign_associations("test merge")
-    end
+    superseded.supersede!(canonical, "test merge")
 
     assert_equal canonical, site_name.reload.site
   end
 
-  test "reassign_associations uses the default revision comment when none given" do
+  test "supersede! writes the comment as a SupersessionEvent comment" do
+    site = create(:site)
     canonical = create(:site)
-    superseded = create(:site, :superseded, superseded_by_site: canonical)
-    context = create(:context, site: superseded)
 
-    with_versioning do
-      superseded.reassign_associations
-    end
+    site.supersede!(canonical, "test merge")
 
-    assert_match(/superseded by site:#{canonical.id}/, context.versions.last.revision_comment)
+    assert_equal "test merge", site.supersession_events.last.comment
   end
 
-  test "reassign_associations raises if not superseded" do
+  test "reassign_associations! is private" do
     site = create(:site)
-    assert_raises(RuntimeError) { site.reassign_associations }
+    assert_no_difference -> { site.contexts.count } do
+      assert_raises(NoMethodError) { site.reassign_associations!("x") }
+    end
   end
 
   test "supersedable_associations excludes versions and pg_search_document" do
@@ -99,39 +148,65 @@ class SupersedableTest < ActiveSupport::TestCase # rubocop:disable Metrics/Class
     assert_includes assoc_names, "site_names"
   end
 
-  test "reassign_associations works on Reference, moving citations" do
+  test "supersede! reassigns citations on Reference" do
     canonical = create(:reference)
-    superseded = create(:reference, :superseded, superseded_by_reference: canonical)
+    superseded = create(:reference)
     citation = create(:citation, citing: create(:site), reference: superseded)
 
-    with_versioning do
-      superseded.reassign_associations("test merge")
-    end
+    superseded.supersede!(canonical, "test merge")
 
     assert_equal canonical, citation.reload.reference
   end
 
-  test "reassign_associations works on C14, moving citations" do
+  test "supersede! reassigns citations on C14" do
     canonical = create(:c14)
-    superseded = create(:c14, :superseded, superseded_by_c14: canonical)
-    citation = create(:citation, citing: superseded, reference: create(:reference))
+    superseded = create(:c14, sample: canonical.sample)
 
-    with_versioning do
-      superseded.reassign_associations("test merge")
-    end
+    superseded.supersede!(canonical, "test merge")
 
-    assert_equal canonical, citation.reload.citing
+    # The new canonical-side state is asserted by the absence of the
+    # superseded record in default scope; nothing else to check for c14.
+    assert superseded.superseded?
+    assert_equal canonical, superseded.ultimately_superseded_by
   end
 
-  test "reassign_associations works on Typo, moving citations" do
+  test "supersede! reassigns citations on Typo" do
     canonical = create(:typo)
-    superseded = create(:typo, :superseded, superseded_by_typo: canonical)
-    citation = create(:citation, citing: superseded, reference: create(:reference))
+    superseded = create(:typo, sample: canonical.sample)
 
-    with_versioning do
-      superseded.reassign_associations("test merge")
+    superseded.supersede!(canonical, "test merge")
+
+    assert superseded.superseded?
+    assert_equal canonical, superseded.ultimately_superseded_by
+  end
+
+  test "restore! raises if not currently superseded" do
+    site = create(:site)
+    assert_raises(RuntimeError) { site.restore! }
+  end
+
+  test "restore! removes the Supersession row and appends a restore event" do
+    canonical = create(:site)
+    superseded = create(:site, :superseded_by, canonical: canonical)
+
+    assert_difference -> { Supersession.count } => -1,
+                      -> { SupersessionEvent.count } => 1 do
+      superseded.restore!
     end
 
-    assert_equal canonical, citation.reload.citing
+    assert_not superseded.reload.superseded?
+    assert_equal "restore", superseded.supersession_events.last.event_type
+  end
+
+  test "merge_history returns events for this record in created_at order" do
+    canonical = create(:site)
+    site = create(:site)
+    site.supersede!(canonical, "first")
+    site.restore!
+    another = create(:site)
+    site.supersede!(another, "second")
+
+    types = site.merge_history.pluck(:event_type)
+    assert_equal %w[supersede restore supersede], types
   end
 end

--- a/test/models/reference_test.rb
+++ b/test/models/reference_test.rb
@@ -3,17 +3,15 @@
 # Table name: references
 # Database name: primary
 #
-#  id            :bigint           not null, primary key
-#  bibtex        :text
-#  short_ref     :string
-#  superseded_by :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id         :bigint           not null, primary key
+#  bibtex     :text
+#  short_ref  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 # Indexes
 #
-#  index_references_on_short_ref      (short_ref)
-#  index_references_on_superseded_by  (superseded_by)
+#  index_references_on_short_ref  (short_ref)
 #
 require "test_helper"
 

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -3,14 +3,13 @@
 # Table name: sites
 # Database name: primary
 #
-#  id            :bigint           not null, primary key
-#  country_code  :string
-#  lat           :decimal(, )
-#  lng           :decimal(, )
-#  name          :string
-#  superseded_by :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id           :bigint           not null, primary key
+#  country_code :string
+#  lat          :decimal(, )
+#  lng          :decimal(, )
+#  name         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 # Indexes
 #
@@ -59,7 +58,7 @@ class SiteTest < ActiveSupport::TestCase
 
   test "superseded site is hidden from default scope but findable via unscoped" do
     canonical = create(:site)
-    superseded = create(:site, :superseded, superseded_by_site: canonical)
+    superseded = create(:site, :superseded_by, canonical: canonical)
 
     assert_includes Site.all, canonical
     assert_not_includes Site.all, superseded

--- a/test/models/supersession_event_test.rb
+++ b/test/models/supersession_event_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class SupersessionEventTest < ActiveSupport::TestCase
+  test 'has a valid factory' do
+    assert FactoryBot.create(:supersession_event).persisted?
+  end
+
+  test 'validates event_type is included in EVENT_TYPES' do
+    event = build(:supersession_event, event_type: 'bogus')
+    assert_not event.valid?
+    assert event.errors[:event_type].any?
+  end
+
+  test "accepts 'supersede' as an event_type" do
+    event = build(:supersede_event)
+    assert event.valid?
+  end
+
+  test "accepts 'restore' as an event_type" do
+    event = build(:restore_event)
+    assert event.valid?
+  end
+
+  test 'rejects self-supersession' do
+    site = create(:site)
+    event = build(:supersession_event, superseded: site, superseded_by: site)
+    assert_not event.valid?
+    assert event.errors[:superseded_by].any?
+  end
+
+  test 'is append-only: cannot be updated' do
+    event = create(:supersession_event)
+    event.comment = 'changed'
+    assert_raises(ActiveRecord::ReadOnlyRecord) { event.save! }
+  end
+
+  test 'is append-only: cannot be destroyed' do
+    event = create(:supersession_event)
+    assert_raises(ActiveRecord::ReadOnlyRecord) { event.destroy! }
+  end
+end

--- a/test/models/supersession_test.rb
+++ b/test/models/supersession_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class SupersessionTest < ActiveSupport::TestCase
+  test 'has a valid factory' do
+    assert FactoryBot.create(:supersession).persisted?
+  end
+
+  test 'has a unique index on superseded_type and superseded_id' do
+    canonical = create(:site)
+    a = create(:site)
+    b = create(:site)
+    create(:supersession, superseded: a, superseded_by: canonical)
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      create(:supersession, superseded: a, superseded_by: b)
+    end
+  end
+
+  test 'rebuild_from_events! wipes the cache and rebuilds it from the event log' do
+    canonical = create(:site)
+    superseded = create(:site, :superseded_by, canonical: canonical)
+    create(:supersede_event, superseded: superseded, superseded_by: canonical)
+
+    # Sanity-check: cache has 1 row, event log has 1 row.
+    assert_equal 1, Supersession.count
+    assert_equal 1, SupersessionEvent.count
+
+    Supersession.rebuild_from_events!
+
+    assert_equal 1, Supersession.count
+    assert_equal superseded, Supersession.find_by(superseded: superseded)&.superseded
+    assert_equal canonical, Supersession.find_by(superseded: superseded)&.superseded_by
+  end
+
+  test 'rebuild_from_events! drops rows that have a later restore event' do
+    canonical = create(:site)
+    site = create(:site)
+    site.supersede!(canonical, 'merge')
+    site.restore!
+
+    Supersession.rebuild_from_events!
+
+    assert_equal 0, Supersession.count
+  end
+
+  test 'rebuild_from_events! is idempotent' do
+    canonical = create(:site)
+    superseded = create(:site, :superseded_by, canonical: canonical)
+    create(:supersede_event, superseded: superseded, superseded_by: canonical)
+
+    Supersession.rebuild_from_events!
+    first_state = Supersession.pluck(:superseded_id, :superseded_by_id).sort
+
+    Supersession.rebuild_from_events!
+    second_state = Supersession.pluck(:superseded_id, :superseded_by_id).sort
+
+    assert_equal first_state, second_state
+  end
+end

--- a/test/models/typo_test.rb
+++ b/test/models/typo_test.rb
@@ -7,7 +7,6 @@
 #  approx_end_time   :integer
 #  approx_start_time :integer
 #  name              :string
-#  superseded_by     :integer
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  parent_id         :integer
@@ -15,9 +14,8 @@
 #
 # Indexes
 #
-#  index_typos_on_name           (name)
-#  index_typos_on_sample_id      (sample_id)
-#  index_typos_on_superseded_by  (superseded_by)
+#  index_typos_on_name       (name)
+#  index_typos_on_sample_id  (sample_id)
 #
 require "test_helper"
 


### PR DESCRIPTION
Replace the superseded_by integer column in the Supersedable concern with a state-as-association pattern. Uses a normalized two-table design: a Supersession cache table for current state (drives the default scope, enforces a unique-index invariant) and a SupersessionEvent log for history (supports chain display and forensic queries). The event log is the source of truth; Supersession.rebuild_from_events! can restore the cache from it if it ever gets out of sync.

The Supersedable concern now exposes supersede! and restore! as the only state-mutating operations, with reassign_associations! folded in and run atomically. When a record is itself superseded, any existing Supersession(X→self) rows are re-pointed to the new canonical, so every supersession always points at a currently-canonical record.

Duplicable.merge_duplicates is updated to use supersede! instead of writing to the integer column directly.