### PR TITLE
Reify changes to peripheral records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,8 @@ public/sitemaps/*
 !/app/assets/builds/.keep
 
 /node_modules
+
+
+
+# --- Coding agents ---
+PLAN

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,9 +174,19 @@ Core models (scientific data):
 
 Peripheral models (dependent scientific data):
 
-- Examples: `SiteName`, `Taxon`, `Material`
-- Only meaningful in relation to a core model
-- Changes are tracked on the parent core record
+Two types:
+
+**Owned peripherals** (belong to one core record):
+- Examples: `SiteName`, `LinkedResource`, `FunctionalClassification`, `Citation`
+- Only meaningful in relation to a single core record
+- Changes are tracked on the parent core record via snapshots
+- Can be deleted if not referenced
+
+**Shared peripherals** (shared across multiple core records):
+- Examples: `Material`, `Taxon`
+- Meaningful across multiple core records
+- Changes propagate to ALL referencing core records via snapshots
+- No independent versioning (changes tracked via parent snapshots)
 - Can be deleted if not referenced
 
 Non-scientific models:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,14 @@
 - Made software version visible in page footer and added Zenodo archive link (#436)
 - Removed standalone Typo show view. Typological dates are now only shown
   embedded in Site views (#398)
+- **Migration required:** Peripheral associated records are now
+  snapshotted on Site versions via ActiveSnapshot
+  - Added new tables (snapshots, snapshot_items) and
+    add_snapshot_id_to_versions migration
+  - Site version history now shows a unified diff of both Site
+    changes and peripheral record changes
+- SiteNames and LinkedResources now generate contextual revision comments
+  when added, changed, or removed (e.g. "Added site name.")
 - **Migration required:** Added affiliations to user profiles
 - Added second column to article show views (news and about pages)
   - Showing extended author metadata on news articles

--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ gem 'doorkeeper'
 
 # Versioning
 gem 'paper_trail'
+gem 'active_snapshot'
 
 # Search
 gem 'pg_search'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,9 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_snapshot (1.1.0)
+      activerecord (>= 6.1)
+      railties
     activejob (8.0.5)
       activesupport (= 8.0.5)
       globalid (>= 0.3.6)
@@ -531,6 +534,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_snapshot
   activerecord-session_store
   annotaterb
   bibtex-ruby

--- a/app/helpers/changelog_helper.rb
+++ b/app/helpers/changelog_helper.rb
@@ -6,4 +6,36 @@ module ChangelogHelper
       : []
     (versions + events).sort_by(&:created_at)
   end
+
+  def version_peripheral_diff(version)
+    return nil unless version.try(:snapshot_id).present?
+
+    current = ActiveSnapshot::Snapshot.includes(:snapshot_items).find_by(id: version.snapshot_id)
+    return nil unless current
+
+    previous = PaperTrail::Version
+      .where(item_type: version.item_type, item_id: version.item_id)
+      .where.not(snapshot_id: nil)
+      .where("created_at < ?", version.created_at)
+      .reorder(created_at: :desc)
+      .first
+
+    if previous&.snapshot_id.present?
+      from = ActiveSnapshot::Snapshot.includes(:snapshot_items).find_by(id: previous.snapshot_id)
+      return nil unless from
+
+      ActiveSnapshot::Snapshot.diff(from, current).map do |entry|
+        si = current.snapshot_items.find { |item| item.item_id == entry[:item_id] && item.item_type == entry[:item_type] }
+        si ||= from.snapshot_items.find { |item| item.item_id == entry[:item_id] && item.item_type == entry[:item_type] }
+        entry.merge(child_group_name: si&.child_group_name)
+      end
+    else
+      current.snapshot_items.map { |item|
+        { action: :create, item_type: item.item_type, item_id: item.item_id, child_group_name: item.child_group_name, changes: item.object.transform_values { |v| [nil, v] } }
+      }
+    end
+  rescue => e
+    Rails.logger.warn "Snapshot diff failed for version #{version.id}: #{e.message}"
+    nil
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  include ActiveSnapshot
 end

--- a/app/models/c14.rb
+++ b/app/models/c14.rb
@@ -59,6 +59,8 @@ class C14 < Chron
   include Linkable
   linkable_to :opencontext
 
+  snapshot_peripherals :citations, :linked_resources
+
   include PgSearch::Model
   pg_search_scope :search,
                   against: :lab_identifier,

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -16,6 +16,7 @@
 #
 
 class Citation < ApplicationRecord
+  include Peripheral
   include Mergeable
 
   exact_duplicates_on :citing_type, :citing_id, :reference_id
@@ -24,7 +25,7 @@ class Citation < ApplicationRecord
   # (citing_type, citing_id, reference_id) prevents creation of new
   # duplicates; the rake task handles the backlog of existing duplicates.
 
-  belongs_to :citing, polymorphic: true
+  belongs_to :citing, polymorphic: true, touch: true
   belongs_to :reference
 
   validates :reference,
@@ -36,6 +37,8 @@ class Citation < ApplicationRecord
   acts_as_copy_target # enable CSV exports
 
   after_destroy :destroy_reference_if_orphaned
+
+  revision_comment_parent :citing
 
   def destroy_reference_if_orphaned
     reference.destroy_if_orphaned

--- a/app/models/concerns/peripheral.rb
+++ b/app/models/concerns/peripheral.rb
@@ -1,0 +1,42 @@
+module Peripheral
+  extend ActiveSupport::Concern
+
+  class_methods do
+    # Single-parent pattern: revision comments on parent
+    # Assumes the model has a `belongs_to` with `touch: true` already declared
+    def revision_comment_parent(association_name)
+      before_save :set_parent_revision_comment_on_save, if: -> { parent_responds_to_revision_comment?(association_name) }
+      before_destroy :set_parent_revision_comment_on_destroy, if: -> { parent_responds_to_revision_comment?(association_name) }
+
+      define_method(:set_parent_revision_comment_on_save) do
+        parent = public_send(association_name)
+        parent.revision_comment = new_record? ? "Added #{self.class.label}." : "Changed #{self.class.label}."
+      end
+
+      define_method(:set_parent_revision_comment_on_destroy) do
+        parent = public_send(association_name)
+        parent.revision_comment = "Removed #{self.class.label}."
+      end
+
+      define_method(:parent_responds_to_revision_comment?) do |assoc|
+        parent = public_send(assoc)
+        parent&.respond_to?(:revision_comment=)
+      end
+    end
+
+    # Multi-parent pattern: touch all referencing records on save/destroy
+    def touch_referencing_records(association_name)
+      after_save :touch_referencing_records_with_revision_comment
+      before_destroy :touch_referencing_records_with_revision_comment
+
+      define_method(:touch_referencing_records_with_revision_comment) do
+        comment = new_record? ? "Added #{self.class.label}." : "Changed #{self.class.label}."
+        public_send(association_name).find_each do |record|
+          next unless record.respond_to?(:revision_comment=)
+          record.revision_comment = comment
+          record.touch
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/versioned.rb
+++ b/app/models/concerns/versioned.rb
@@ -3,7 +3,11 @@ module Versioned
   extend ActiveSupport::Concern
 
   included do # instance methods
-    has_paper_trail meta: { revision_comment: :revision_comment }
+    has_paper_trail on: [:create, :update, :destroy, :touch],
+      meta: {
+        revision_comment: :revision_comment,
+        snapshot_id: :create_peripheral_snapshot
+      }
 
     attr_accessor :revision_comment
     #validates :revision_comment, presence: true
@@ -45,6 +49,19 @@ module Versioned
       revision_comment: parent.revision_comment,
       batch_size: batch_size
     )
+  end
+
+  def create_peripheral_snapshot
+    return nil unless self.class.respond_to?(:snapshot_children_proc) && self.class.snapshot_children_proc
+
+    snapshot = create_snapshot!(
+      identifier: "v#{self.class.base_class.model_name.singular}:#{id}:#{Time.current.to_f}",
+      metadata: { source: :paper_trail }
+    )
+    snapshot.id
+  rescue => e
+    Rails.logger.warn "Failed to create peripheral snapshot for #{self.class.name}##{id}: #{e.message}"
+    nil
   end
 
   private

--- a/app/models/concerns/versioned.rb
+++ b/app/models/concerns/versioned.rb
@@ -36,6 +36,18 @@ module Versioned
         )
       end
     end
+
+    ##
+    # DSL for declaring peripheral associations to snapshot
+    # Automatically handles nil values by wrapping in Array and compacting
+    def snapshot_peripherals(*associations)
+      has_snapshot_children do
+        instance = self.class.includes(*associations).find(id)
+        associations.each_with_object({}) do |assoc, hash|
+          hash[assoc] = Array(instance.public_send(assoc)).compact
+        end
+      end
+    end
   end
 
   def self.enqueue(parent:, association:, job:, batch_size:)

--- a/app/models/context.rb
+++ b/app/models/context.rb
@@ -51,6 +51,8 @@ class Context < ApplicationRecord
            as: :assignable,
            dependent: :destroy
 
+  snapshot_peripherals :functional_classifications
+
   # No `after_save :merge_exact_duplicates`: the model-level
   # uniqueness validation and DB unique index already prevent new
   # duplicates. Mergeable is here to power Site#reassign_contexts!

--- a/app/models/functional_classification.rb
+++ b/app/models/functional_classification.rb
@@ -24,7 +24,9 @@
 #  fk_rails_...  (functional_classification_category_id => functional_classification_categories.id)
 #
 class FunctionalClassification < ApplicationRecord
-  belongs_to :assignable, polymorphic: true
+  include Peripheral
+
+  belongs_to :assignable, polymorphic: true, touch: true
   belongs_to :functional_classification_category
 
   enum :confidence, {
@@ -41,6 +43,8 @@ class FunctionalClassification < ApplicationRecord
             }
 
   validates :confidence, presence: true
+
+  revision_comment_parent :assignable
 
   has_paper_trail
   acts_as_copy_target

--- a/app/models/linked_resource.rb
+++ b/app/models/linked_resource.rb
@@ -49,11 +49,18 @@ class LinkedResource < ApplicationRecord
 
   enum :status, { pending: 'pending', approved: 'approved' }
 
-  belongs_to :linkable, polymorphic: true
+  belongs_to :linkable, polymorphic: true, touch: true
+
+  before_save :set_revision_comment_on_save, if: :linkable_is_site?
+  before_destroy :set_revision_comment_on_destroy, if: :linkable_is_site?
 
   # Scopes for filtering matches
   scope :pending, -> { where(status: 'pending') }
   scope :approved, -> { where(status: 'approved') }
+
+  def self.label
+    "external link"
+  end
 
   def external_url
     LinkedResource::Source.find(source)&.url_for(external_id)
@@ -93,6 +100,18 @@ class LinkedResource < ApplicationRecord
   end
 
   private
+
+  def linkable_is_site?
+    linkable.is_a?(Site)
+  end
+
+  def set_revision_comment_on_save
+    linkable.revision_comment = new_record? ? "Added #{self.class.label}." : "Changed #{self.class.label}."
+  end
+
+  def set_revision_comment_on_destroy
+    linkable.revision_comment = "Removed #{self.class.label}."
+  end
 
   def external_id_matches_source_pattern
     source_obj = LinkedResource::Source.find(source)

--- a/app/models/linked_resource.rb
+++ b/app/models/linked_resource.rb
@@ -19,6 +19,7 @@
 #  index_linked_resources_on_linkable_type_and_linkable_id  (linkable_type,linkable_id)
 #
 class LinkedResource < ApplicationRecord
+  include Peripheral
   include Turbo::Broadcastable
 
   # Each known source is a module under LinkedResource::Sources that
@@ -51,8 +52,7 @@ class LinkedResource < ApplicationRecord
 
   belongs_to :linkable, polymorphic: true, touch: true
 
-  before_save :set_revision_comment_on_save, if: :linkable_is_site?
-  before_destroy :set_revision_comment_on_destroy, if: :linkable_is_site?
+  revision_comment_parent :linkable
 
   # Scopes for filtering matches
   scope :pending, -> { where(status: 'pending') }
@@ -100,18 +100,6 @@ class LinkedResource < ApplicationRecord
   end
 
   private
-
-  def linkable_is_site?
-    linkable.is_a?(Site)
-  end
-
-  def set_revision_comment_on_save
-    linkable.revision_comment = new_record? ? "Added #{self.class.label}." : "Changed #{self.class.label}."
-  end
-
-  def set_revision_comment_on_destroy
-    linkable.revision_comment = "Removed #{self.class.label}."
-  end
 
   def external_id_matches_source_pattern
     source_obj = LinkedResource::Source.find(source)

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -14,9 +14,10 @@
 #
 
 class Material < ApplicationRecord
+  include Peripheral
+
   default_scope { order(name: :asc) }
 
-  include Versioned
   include Mergeable
 
   exact_duplicates_on :name
@@ -24,6 +25,8 @@ class Material < ApplicationRecord
   has_many :samples, inverse_of: :material
 
   validates :name, presence: true
+
+  touch_referencing_records :samples
 
   after_save :merge_exact_duplicates
   validate :no_exact_duplicate, on: :create

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -66,6 +66,8 @@ class Sample < ApplicationRecord
   validates_associated :taxon
   delegate :name, to: :taxon, prefix: true, allow_nil: true
 
+  snapshot_peripherals :material, :taxon
+
   after_destroy :destroy_material_if_orphaned
   after_destroy :destroy_taxon_if_orphaned
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -48,6 +48,11 @@ class Site < ApplicationRecord
   has_many :linked_resources, as: :linkable, dependent: :destroy
   has_many :functional_classifications, as: :assignable, dependent: :destroy
 
+  has_snapshot_children do
+    instance = self.class.includes(:site_names, :linked_resources).find(id)
+    { site_names: instance.site_names, linked_resources: instance.linked_resources }
+  end
+
   composed_of :coordinates,
               mapping: [%w[lng longitude], %w[lat latitude]],
               allow_nil: true,

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -48,10 +48,7 @@ class Site < ApplicationRecord
   has_many :linked_resources, as: :linkable, dependent: :destroy
   has_many :functional_classifications, as: :assignable, dependent: :destroy
 
-  has_snapshot_children do
-    instance = self.class.includes(:site_names, :linked_resources).find(id)
-    { site_names: instance.site_names, linked_resources: instance.linked_resources }
-  end
+  snapshot_peripherals :site_names, :linked_resources, :functional_classifications, :citations, :site_types
 
   composed_of :coordinates,
               mapping: [%w[lng longitude], %w[lat latitude]],

--- a/app/models/site_name.rb
+++ b/app/models/site_name.rb
@@ -20,12 +20,13 @@
 #
 
 class SiteName < ApplicationRecord
+  include Peripheral
+
   belongs_to :site, touch: true
 
   validates :name, presence: true
 
-  before_save :set_revision_comment_on_save, if: :site
-  before_destroy :set_revision_comment_on_destroy, if: :site
+  revision_comment_parent :site
 
   def self.label
     "site name"
@@ -33,15 +34,5 @@ class SiteName < ApplicationRecord
 
   def label
     name
-  end
-
-  private
-
-  def set_revision_comment_on_save
-    site.revision_comment = new_record? ? "Added #{self.class.label}." : "Changed #{self.class.label}."
-  end
-
-  def set_revision_comment_on_destroy
-    site.revision_comment = "Removed #{self.class.label}."
   end
 end

--- a/app/models/site_name.rb
+++ b/app/models/site_name.rb
@@ -20,15 +20,28 @@
 #
 
 class SiteName < ApplicationRecord
-  belongs_to :site
+  belongs_to :site, touch: true
 
   validates :name, presence: true
 
+  before_save :set_revision_comment_on_save, if: :site
+  before_destroy :set_revision_comment_on_destroy, if: :site
+
   def self.label
-    "site alias"
+    "site name"
   end
 
   def label
     name
+  end
+
+  private
+
+  def set_revision_comment_on_save
+    site.revision_comment = new_record? ? "Added #{self.class.label}." : "Changed #{self.class.label}."
+  end
+
+  def set_revision_comment_on_destroy
+    site.revision_comment = "Removed #{self.class.label}."
   end
 end

--- a/app/models/site_type.rb
+++ b/app/models/site_type.rb
@@ -15,6 +15,8 @@
 #
 
 class SiteType < ApplicationRecord
+  include Peripheral
+
   default_scope { order(name: :asc) }
 
   include PgSearch::Model
@@ -24,9 +26,11 @@ class SiteType < ApplicationRecord
 
   acts_as_copy_target # enable CSV exports
 
-  has_many :sites, inverse_of: :site_type
+  has_and_belongs_to_many :sites
 
   validates :name, presence: true
+
+  touch_referencing_records :sites
 
   def self.label
     "site type"
@@ -35,5 +39,4 @@ class SiteType < ApplicationRecord
   def label
     name
   end
-
 end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -16,7 +16,7 @@
 #
 
 class Taxon < ApplicationRecord
-  include Versioned
+  include Peripheral
   include Mergeable
 
   exact_duplicates_on :name, { gbif_id: [:nil_matches_nil] }
@@ -24,6 +24,8 @@ class Taxon < ApplicationRecord
   has_many :samples
 
   validates :name, presence: true
+
+  touch_referencing_records :samples
 
   after_save :enqueue_gbif_sync
   after_save :merge_exact_duplicates
@@ -40,10 +42,6 @@ class Taxon < ApplicationRecord
     using: { tsearch: { prefix: true } } # match partial words
 
   acts_as_copy_target # enable CSV exports
-
-  validates :name, presence: true
-
-  has_many :samples
 
   scope :with_samples_count, -> {
     select <<~SQL

--- a/app/models/typo.rb
+++ b/app/models/typo.rb
@@ -27,6 +27,8 @@ class Typo < Chron
 
   validates :name, presence: true
 
+  snapshot_peripherals :citations
+
   include PgSearch::Model
   pg_search_scope :search,
                   against: :name,

--- a/app/views/application/paper_trail/_changes.html.erb
+++ b/app/views/application/paper_trail/_changes.html.erb
@@ -27,3 +27,70 @@
 <% elsif entry.event_type == "restore" %>
   <p>Restored</p>
 <% end %>
+
+<% if entry.respond_to?(:snapshot_id) && entry.snapshot_id.present? && (diff = version_peripheral_diff(entry)).present? %>
+  <%
+    hidden_attrs = %w[id created_at updated_id linkable_id linkable_type site_id]
+    parent_class = entry.item_type.constantize
+    groups = {}
+    diff.each do |change|
+      key = change[:child_group_name] || change[:item_type]
+      groups[key] ||= { entries: [] }
+
+      next if change[:action] == :update && change[:changes].none? { |attr, _| !hidden_attrs.include?(attr.to_s) }
+
+      groups[key][:entries] << change
+    end
+  %>
+  <% groups.each do |key, group| %>
+    <% next if group[:entries].empty? %>
+    <%
+      heading = if group[:entries].first[:child_group_name]
+                  label = group[:entries].first[:item_type].constantize.label
+                  macro = parent_class.reflect_on_association(key)&.macro
+                  macro == :has_many ? label.pluralize.humanize : label.humanize
+                else
+                  key.constantize.label.humanize
+                end
+    %>
+    <div class="ms-2 mt-1">
+      <dt class="small text-muted"><%= heading %></dt>
+      <% group[:entries].each do |change| %>
+        <% case change[:action] %>
+        <% when :create %>
+          <div class="d-flex small">
+            <%= bs_icon "plus-circle", class: "me-1" %>
+            <span>
+              Added
+              <% if (name = change[:changes]["name"] || change[:changes][:name]) %>
+                "<%= name[1] %>"
+              <% end %>
+            </span>
+          </div>
+        <% when :destroy %>
+          <div class="d-flex small">
+            <%= bs_icon "dash-circle", class: "me-1" %>
+            <span>
+              Deleted
+              <% if (name = change[:changes][:name]) %>
+                "<%= name.first %>"
+              <% end %>
+            </span>
+          </div>
+        <% when :update %>
+          <% change[:changes].each do |attr, values| %>
+            <% next if hidden_attrs.include?(attr.to_s) %>
+            <div class="d-flex small">
+              <dt class="me-1"><%= attr.to_s.humanize %>:</dt>
+              <dd class="flex-grow-1 ms-1">
+                <%= values.first.present? ? values.first : na_value %>
+                &rarr;
+                <%= values.second.present? ? values.second : na_value %>
+              </dd>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/application/paper_trail/_changes.html.erb
+++ b/app/views/application/paper_trail/_changes.html.erb
@@ -28,7 +28,7 @@
   <p>Restored</p>
 <% end %>
 
-<% if entry.respond_to?(:snapshot_id) && entry.snapshot_id.present? && (diff = version_peripheral_diff(entry)).present? %>
+<% if entry.is_a?(PaperTrail::Version) && entry.snapshot_id.present? && (diff = version_peripheral_diff(entry)).present? %>
   <%
     hidden_attrs = %w[id created_at updated_id linkable_id linkable_type site_id]
     parent_class = entry.item_type.constantize

--- a/db/migrate/20260623190543_create_snapshots_tables.rb
+++ b/db/migrate/20260623190543_create_snapshots_tables.rb
@@ -1,0 +1,28 @@
+class CreateSnapshotsTables < ActiveRecord::Migration::Current
+
+  def change
+    create_table :snapshots do |t|
+      t.belongs_to :item, polymorphic: true, null: false, index: true
+      t.belongs_to :user, polymorphic: true
+
+      t.string :identifier, index: true
+      t.index [:identifier, :item_id, :item_type], unique: true
+
+      t.json :metadata
+
+      t.datetime :created_at, null: false
+    end
+
+    create_table :snapshot_items do |t|
+      t.belongs_to :snapshot, null: false, index: true
+      t.belongs_to :item, polymorphic: true, null: false, index: true
+      t.index [:snapshot_id, :item_id, :item_type]
+
+      t.json :object, null: false
+
+      t.datetime :created_at, null: false
+      t.string :child_group_name
+    end
+  end
+
+end

--- a/db/migrate/20260623190612_add_snapshot_id_to_versions.rb
+++ b/db/migrate/20260623190612_add_snapshot_id_to_versions.rb
@@ -1,0 +1,6 @@
+class AddSnapshotIdToVersions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :versions, :snapshot_id, :bigint
+    add_index :versions, :snapshot_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -431,12 +431,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_07_193908) do
     t.index ["sample_id"], name: "index_typos_on_sample_id"
   end
 
-  create_table "unversioned_children", force: :cascade do |t|
-    t.integer "versioned_parent_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "user_profiles", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -462,22 +456,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_07_193908) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "versioned_children", force: :cascade do |t|
-    t.integer "versioned_parent_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
 
-  create_table "versioned_parents", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "versioned_singles", force: :cascade do |t|
-    t.integer "versioned_parent_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
 
   create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -341,6 +341,32 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_07_193908) do
     t.index ["name"], name: "index_sites_on_name"
   end
 
+  create_table "snapshot_items", force: :cascade do |t|
+    t.bigint "snapshot_id", null: false
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.json "object", null: false
+    t.datetime "created_at", null: false
+    t.string "child_group_name"
+    t.index ["item_type", "item_id"], name: "index_snapshot_items_on_item"
+    t.index ["snapshot_id", "item_id", "item_type"], name: "index_snapshot_items_on_snapshot_id_and_item_id_and_item_type"
+    t.index ["snapshot_id"], name: "index_snapshot_items_on_snapshot_id"
+  end
+
+  create_table "snapshots", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "user_type"
+    t.bigint "user_id"
+    t.string "identifier"
+    t.json "metadata"
+    t.datetime "created_at", null: false
+    t.index ["identifier", "item_id", "item_type"], name: "index_snapshots_on_identifier_and_item_id_and_item_type", unique: true
+    t.index ["identifier"], name: "index_snapshots_on_identifier"
+    t.index ["item_type", "item_id"], name: "index_snapshots_on_item"
+    t.index ["user_type", "user_id"], name: "index_snapshots_on_user"
+  end
+
   create_table "sources", force: :cascade do |t|
     t.string "name", null: false
     t.string "version"
@@ -405,6 +431,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_07_193908) do
     t.index ["sample_id"], name: "index_typos_on_sample_id"
   end
 
+  create_table "unversioned_children", force: :cascade do |t|
+    t.integer "versioned_parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "user_profiles", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -430,6 +462,23 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_07_193908) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "versioned_children", force: :cascade do |t|
+    t.integer "versioned_parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "versioned_parents", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "versioned_singles", force: :cascade do |t|
+    t.integer "versioned_parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
     t.bigint "item_id", null: false
@@ -441,8 +490,10 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_07_193908) do
     t.text "revision_comment"
     t.jsonb "new_object"
     t.jsonb "object_changes"
+    t.bigint "snapshot_id"
     t.index ["event"], name: "index_versions_on_event"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+    t.index ["snapshot_id"], name: "index_versions_on_snapshot_id"
     t.index ["whodunnit"], name: "index_versions_on_whodunnit"
   end
 

--- a/lib/tasks/backfill_snapshots.rake
+++ b/lib/tasks/backfill_snapshots.rake
@@ -36,11 +36,11 @@ end
 
 def collect_peripherals(site)
   site_names = {}
-  lod_links = {}
+  linked_resources = {}
 
   # Current peripherals
   site.site_names.each { |r| site_names[r.id] = r.versions.order(:created_at).to_a }
-  site.lod_links.each { |r| lod_links[r.id] = r.versions.order(:created_at).to_a }
+  site.linked_resources.each { |r| linked_resources[r.id] = r.versions.order(:created_at).to_a }
 
   # Deleted SiteNames (via PaperTrail)
   deleted_site_name_ids(site.id).each do |id|
@@ -49,14 +49,14 @@ def collect_peripherals(site)
       .order(:created_at).to_a
   end
 
-  # Deleted LodLinks (via PaperTrail)
-  deleted_lod_link_ids(site.id).each do |id|
-    next if lod_links.key?(id)
-    lod_links[id] = PaperTrail::Version.where(item_type: "LodLink", item_id: id)
+  # Deleted LinkedResources (via PaperTrail)
+  deleted_linked_resource_ids(site.id).each do |id|
+    next if linked_resources.key?(id)
+    linked_resources[id] = PaperTrail::Version.where(item_type: "LinkedResource", item_id: id)
       .order(:created_at).to_a
   end
 
-  { site_names: site_names, lod_links: lod_links }
+  { site_names: site_names, linked_resources: linked_resources }
 end
 
 def deleted_site_name_ids(site_id)
@@ -73,13 +73,13 @@ def deleted_site_name_ids(site_id)
   (via_object + via_changes).uniq
 end
 
-def deleted_lod_link_ids(site_id)
-  via_object = PaperTrail::Version.where(item_type: "LodLink")
+def deleted_linked_resource_ids(site_id)
+  via_object = PaperTrail::Version.where(item_type: "LinkedResource")
     .where_object(linkable_id: site_id, linkable_type: "Site")
     .distinct
     .pluck(:item_id)
 
-  via_changes = PaperTrail::Version.where(item_type: "LodLink")
+  via_changes = PaperTrail::Version.where(item_type: "LinkedResource")
     .where_object_changes(linkable_id: [site_id])
     .where_object_changes(linkable_type: ["Site"])
     .distinct
@@ -134,10 +134,10 @@ def build_version_snapshot(site, version, peripherals)
     snapshot.build_snapshot_item(p_state, child_group_name: "site_names")
   end
 
-  peripherals[:lod_links].each_value do |pvs|
-    p_state = peripheral_state_at(LodLink, pvs, time)
+  peripherals[:linked_resources].each_value do |pvs|
+    p_state = peripheral_state_at(LinkedResource, pvs, time)
     next unless p_state
-    snapshot.build_snapshot_item(p_state, child_group_name: "lod_links")
+    snapshot.build_snapshot_item(p_state, child_group_name: "linked_resources")
   end
 
   snapshot.save!

--- a/test/models/concerns/versioned_async_destroy_test.rb
+++ b/test/models/concerns/versioned_async_destroy_test.rb
@@ -1,0 +1,154 @@
+require "test_helper"
+
+class VersionedAsyncDestroyTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  # after_destroy_commit must fire for async destroy tests
+  self.use_transactional_tests = false
+
+  #
+  # Disposable schema for this test only
+  #
+  setup do
+    ActiveRecord::Schema.define do
+      suppress_messages do
+        create_table :versioned_parents, force: true do |t|
+          t.timestamps
+        end
+
+        create_table :versioned_children, force: true do |t|
+          t.integer :versioned_parent_id
+          t.timestamps
+        end
+
+        create_table :versioned_singles, force: true do |t|
+          t.integer :versioned_parent_id
+          t.timestamps
+        end
+
+        create_table :unversioned_children, force: true do |t|
+          t.integer :versioned_parent_id
+          t.timestamps
+        end
+      end
+    end
+  end
+
+  teardown do
+    PaperTrail::Version.where(item_type: [
+      "VersionedAsyncDestroyTest::VersionedParent",
+      "VersionedAsyncDestroyTest::VersionedChild",
+      "VersionedAsyncDestroyTest::VersionedSingle"
+    ]).delete_all
+
+    # Use safe_constantize to avoid errors if classes aren't loaded
+    %w[
+      VersionedAsyncDestroyTest::VersionedSingle
+      VersionedAsyncDestroyTest::VersionedChild
+      VersionedAsyncDestroyTest::VersionedParent
+      VersionedAsyncDestroyTest::UnversionedChild
+    ].each do |class_name|
+      class_name.safe_constantize&.delete_all
+    end
+  end
+
+  #
+  # Test-only models
+  #
+  class VersionedParent < ApplicationRecord
+    self.table_name = "versioned_parents"
+
+    include Versioned
+
+    has_many :children,
+      class_name: "VersionedAsyncDestroyTest::VersionedChild",
+      foreign_key: :versioned_parent_id,
+      dependent: :destroy
+
+    has_one :single,
+      class_name: "VersionedAsyncDestroyTest::VersionedSingle",
+      foreign_key: :versioned_parent_id,
+      dependent: :destroy
+
+    has_many :unversioned_children,
+      class_name: "VersionedAsyncDestroyTest::UnversionedChild",
+      foreign_key: :versioned_parent_id,
+      dependent: :destroy
+
+    destroy_async_with_paper_trail :children
+    destroy_async_with_paper_trail :single
+    destroy_async_with_paper_trail :unversioned_children
+  end
+
+  class VersionedChild < ApplicationRecord
+    self.table_name = "versioned_children"
+
+    include Versioned
+
+    belongs_to :parent,
+      class_name: "VersionedAsyncDestroyTest::VersionedParent",
+      foreign_key: :versioned_parent_id
+  end
+
+  class VersionedSingle < ApplicationRecord
+    self.table_name = "versioned_singles"
+
+    include Versioned
+
+    belongs_to :parent,
+      class_name: "VersionedAsyncDestroyTest::VersionedParent",
+      foreign_key: :versioned_parent_id
+  end
+
+  # NOTE: intentionally does NOT include Versioned
+  class UnversionedChild < ApplicationRecord
+    self.table_name = "unversioned_children"
+
+    belongs_to :parent,
+      class_name: "VersionedAsyncDestroyTest::VersionedParent",
+      foreign_key: :versioned_parent_id
+  end
+
+  #
+  # Tests
+  #
+
+  test "revision_comment propagates for async dependent destroy (has_many and has_one)" do
+    parent = VersionedParent.create!
+
+    child  = VersionedChild.create!(parent: parent)
+    single = VersionedSingle.create!(parent: parent)
+
+    parent.revision_comment = "Async delete parent"
+
+    perform_enqueued_jobs do
+      parent.destroy
+    end
+
+    assert_not VersionedChild.exists?(child.id)
+    assert_not VersionedSingle.exists?(single.id)
+
+    assert_equal "Async delete parent", child.versions.last.revision_comment
+    assert_equal "Async delete parent", single.versions.last.revision_comment
+  end
+
+  test "non-Versioned children are skipped gracefully" do
+    parent = VersionedParent.create!
+
+    unversioned = UnversionedChild.create!(parent: parent)
+
+    parent.revision_comment = "Delete parent"
+
+    perform_enqueued_jobs do
+      parent.destroy
+    end
+
+    assert_not UnversionedChild.exists?(unversioned.id),
+      "Expected unversioned child to be destroyed"
+
+    # No PaperTrail versions should exist for unversioned models
+    assert_raises(NoMethodError) do
+      unversioned.versions
+    end
+  end
+end

--- a/test/models/concerns/versioned_test.rb
+++ b/test/models/concerns/versioned_test.rb
@@ -30,6 +30,17 @@ class VersionedTest < ActiveSupport::TestCase
           t.integer :versioned_parent_id
           t.timestamps
         end
+
+        create_table :snapshot_parents, force: true do |t|
+          t.string :name
+          t.timestamps
+        end
+
+        create_table :snapshot_peripherals, force: true do |t|
+          t.integer :snapshot_parent_id
+          t.string :name
+          t.timestamps
+        end
       end
     end
   end
@@ -45,6 +56,31 @@ class VersionedTest < ActiveSupport::TestCase
   #
   # Test-only models
   #
+  class SnapshotParent < ApplicationRecord
+    self.table_name = "snapshot_parents"
+
+    include Versioned
+
+    has_many :peripherals,
+      class_name: "VersionedTest::SnapshotPeripheral",
+      foreign_key: :snapshot_parent_id,
+      dependent: :destroy
+
+    has_snapshot_children do
+      instance = self.class.includes(:peripherals).find(id)
+      { peripherals: instance.peripherals }
+    end
+  end
+
+  class SnapshotPeripheral < ApplicationRecord
+    self.table_name = "snapshot_peripherals"
+
+    belongs_to :parent,
+      class_name: "VersionedTest::SnapshotParent",
+      foreign_key: :snapshot_parent_id,
+      touch: true
+  end
+
   class VersionedParent < ApplicationRecord
     self.table_name = "versioned_parents"
 
@@ -133,6 +169,80 @@ class VersionedTest < ActiveSupport::TestCase
 
     assert_equal "Async delete parent", child.versions.last.revision_comment
     assert_equal "Async delete parent", single.versions.last.revision_comment
+  end
+
+  test "create_peripheral_snapshot stores snapshot_id on create" do
+    with_versioning do
+      parent = SnapshotParent.create!(name: "original")
+      version = parent.versions.last
+
+      assert version.snapshot_id.present?,
+        "Expected snapshot_id on create version"
+
+      snapshot = ActiveSnapshot::Snapshot.find(version.snapshot_id)
+      assert_equal "VersionedTest::SnapshotParent", snapshot.item_type
+      assert_equal parent.id, snapshot.item_id
+    end
+  end
+
+  test "create_peripheral_snapshot stores snapshot_id on update" do
+    with_versioning do
+      parent = SnapshotParent.create!(name: "original")
+      parent.update!(name: "updated")
+      version = parent.versions.last
+
+      assert version.snapshot_id.present?,
+        "Expected snapshot_id on update version"
+
+      snapshot = ActiveSnapshot::Snapshot.find(version.snapshot_id)
+      peripheral_items = snapshot.snapshot_items.where.not(child_group_name: nil)
+      assert_equal 0, peripheral_items.size, "Expected no peripheral items yet"
+    end
+  end
+
+  test "peripheral create triggers parent version with snapshot" do
+    with_versioning do
+      parent = SnapshotParent.create!(name: "test")
+      peripheral = SnapshotPeripheral.create!(parent: parent, name: "child")
+
+      version = parent.versions.reorder(created_at: :desc).first
+      assert version.snapshot_id.present?,
+        "Expected snapshot_id after peripheral create"
+
+      snapshot = ActiveSnapshot::Snapshot.find(version.snapshot_id)
+      items = snapshot.snapshot_items.where(child_group_name: "peripherals")
+      assert_equal 1, items.size
+      assert_equal "child", items.first.object["name"]
+    end
+  end
+
+  test "peripheral update triggers parent version with snapshot" do
+    with_versioning do
+      parent = SnapshotParent.create!(name: "test")
+      peripheral = SnapshotPeripheral.create!(parent: parent, name: "child")
+
+      peripheral.update!(name: "updated child")
+
+      version = parent.versions.reorder(created_at: :desc).first
+      assert version.snapshot_id.present?,
+        "Expected snapshot_id after peripheral update"
+
+      snapshot = ActiveSnapshot::Snapshot.find(version.snapshot_id)
+      items = snapshot.snapshot_items.where(child_group_name: "peripherals")
+      assert_equal 1, items.size
+      assert_equal "updated child", items.first.object["name"]
+    end
+  end
+
+  test "model without has_snapshot_children has nil snapshot_id" do
+    with_versioning do
+      # VersionedParent does not define has_snapshot_children
+      parent = VersionedParent.create!
+      version = parent.versions.last
+
+      assert_nil version.snapshot_id,
+        "Expected nil snapshot_id for model without has_snapshot_children"
+    end
   end
 
   test "non-Versioned children are skipped gracefully" do

--- a/test/models/concerns/versioned_test.rb
+++ b/test/models/concerns/versioned_test.rb
@@ -1,11 +1,6 @@
 require "test_helper"
 
 class VersionedTest < ActiveSupport::TestCase
-  include ActiveJob::TestHelper
-
-  # after_destroy_commit must fire
-  self.use_transactional_tests = false
-
   #
   # Disposable schema for this test only
   #
@@ -22,11 +17,6 @@ class VersionedTest < ActiveSupport::TestCase
         end
 
         create_table :versioned_singles, force: true do |t|
-          t.integer :versioned_parent_id
-          t.timestamps
-        end
-
-        create_table :unversioned_children, force: true do |t|
           t.integer :versioned_parent_id
           t.timestamps
         end
@@ -49,8 +39,15 @@ class VersionedTest < ActiveSupport::TestCase
     PaperTrail::Version.where(item_type: [
       "VersionedTest::VersionedParent",
       "VersionedTest::VersionedChild",
-      "VersionedTest::VersionedSingle"
+      "VersionedTest::VersionedSingle",
+      "VersionedTest::SnapshotParent",
+      "VersionedTest::SnapshotPeripheral"
     ]).delete_all
+
+    ActiveSnapshot::Snapshot.where(item_type: [
+      "VersionedTest::SnapshotParent",
+      "VersionedTest::SnapshotPeripheral"
+    ]).destroy_all
   end
 
   #
@@ -95,15 +92,6 @@ class VersionedTest < ActiveSupport::TestCase
       class_name: "VersionedTest::VersionedSingle",
       foreign_key: :versioned_parent_id,
       dependent: :destroy
-
-    has_many :unversioned_children,
-      class_name: "VersionedTest::UnversionedChild",
-      foreign_key: :versioned_parent_id,
-      dependent: :destroy
-
-    destroy_async_with_paper_trail :children
-    destroy_async_with_paper_trail :single
-    destroy_async_with_paper_trail :unversioned_children
   end
 
   class VersionedChild < ApplicationRecord
@@ -126,15 +114,6 @@ class VersionedTest < ActiveSupport::TestCase
       foreign_key: :versioned_parent_id
   end
 
-  # NOTE: intentionally does NOT include Versioned
-  class UnversionedChild < ApplicationRecord
-    self.table_name = "unversioned_children"
-
-    belongs_to :parent,
-      class_name: "VersionedTest::VersionedParent",
-      foreign_key: :versioned_parent_id
-  end
-
   #
   # Tests
   #
@@ -150,25 +129,6 @@ class VersionedTest < ActiveSupport::TestCase
 
     assert_equal "Sync delete parent", child.versions.last.revision_comment
     assert_equal "Sync delete parent", single.versions.last.revision_comment
-  end
-
-  test "revision_comment propagates for async dependent destroy (has_many and has_one)" do
-    parent = VersionedParent.create!
-
-    child  = VersionedChild.create!(parent: parent)
-    single = VersionedSingle.create!(parent: parent)
-
-    parent.revision_comment = "Async delete parent"
-
-    perform_enqueued_jobs do
-      parent.destroy
-    end
-
-    assert_not VersionedChild.exists?(child.id)
-    assert_not VersionedSingle.exists?(single.id)
-
-    assert_equal "Async delete parent", child.versions.last.revision_comment
-    assert_equal "Async delete parent", single.versions.last.revision_comment
   end
 
   test "create_peripheral_snapshot stores snapshot_id on create" do
@@ -242,26 +202,6 @@ class VersionedTest < ActiveSupport::TestCase
 
       assert_nil version.snapshot_id,
         "Expected nil snapshot_id for model without has_snapshot_children"
-    end
-  end
-
-  test "non-Versioned children are skipped gracefully" do
-    parent = VersionedParent.create!
-
-    unversioned = UnversionedChild.create!(parent: parent)
-
-    parent.revision_comment = "Delete parent"
-
-    perform_enqueued_jobs do
-      parent.destroy
-    end
-
-    assert_not UnversionedChild.exists?(unversioned.id),
-      "Expected unversioned child to be destroyed"
-
-    # No PaperTrail versions should exist for unversioned models
-    assert_raises(NoMethodError) do
-      unversioned.versions
     end
   end
 end

--- a/test/models/site_test.rb
+++ b/test/models/site_test.rb
@@ -319,4 +319,70 @@ class SiteTest < ActiveSupport::TestCase
     assert_equal 0, FunctionalClassification.where(assignable_type: 'Site', assignable_id: dupe.id).count
     assert_equal 1, FunctionalClassification.where(assignable_type: 'Site', assignable_id: canonical.id).count
   end
+
+  #
+  # Peripheral snapshots
+  #
+
+  test "site update creates version with peripheral snapshot" do
+    with_versioning do
+      site = create(:site, name: "original")
+      site.update!(name: "updated")
+
+      version = site.versions.last
+      assert version.snapshot_id.present?,
+        "Expected snapshot_id on site update version"
+    end
+  end
+
+  test "site update snapshot captures peripherals" do
+    with_versioning do
+      site = create(:site, :with_site_names, :with_linked_resources, linked_resources_count: 1)
+      site.update!(name: "renamed")
+
+      version = site.versions.last
+      snapshot = ActiveSnapshot::Snapshot.find(version.snapshot_id)
+
+      site_name_items = snapshot.snapshot_items.where(child_group_name: "site_names")
+      assert_equal site.site_names.count, site_name_items.size,
+        "Expected snapshot to capture site_names"
+
+      linked_resource_items = snapshot.snapshot_items.where(child_group_name: "linked_resources")
+      assert_equal site.linked_resources.count, linked_resource_items.size,
+        "Expected snapshot to capture linked_resources"
+    end
+  end
+
+  test "site name create triggers site version with snapshot" do
+    with_versioning do
+      site = create(:site)
+      create(:site_name, site: site, name: "New Name")
+
+      version = site.versions.reorder(created_at: :desc).first
+      assert version.snapshot_id.present?,
+        "Expected snapshot_id after site_name create"
+
+      snapshot = ActiveSnapshot::Snapshot.find(version.snapshot_id)
+      items = snapshot.snapshot_items.where(child_group_name: "site_names")
+      assert_equal 1, items.size
+      assert_equal "New Name", items.first.object["name"]
+    end
+  end
+
+  test "linked resource create triggers linkable version with snapshot" do
+    with_versioning do
+      site = create(:site)
+      create(:linked_resource, linkable: site, source: "Wikidata", external_id: "Q12345")
+
+      version = site.versions.reorder(created_at: :desc).first
+      assert version.snapshot_id.present?,
+        "Expected snapshot_id after linked_resource create"
+
+      snapshot = ActiveSnapshot::Snapshot.find(version.snapshot_id)
+      items = snapshot.snapshot_items.where(child_group_name: "linked_resources")
+      assert_equal 1, items.size
+      assert_equal "Wikidata", items.first.object["source"]
+      assert_equal "Q12345", items.first.object["external_id"]
+    end
+  end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,9 +401,9 @@ browserslist@^4.23.3:
     update-browserslist-db "^1.1.1"
 
 caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001669:
-  version "1.0.30001806"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz"
-  integrity sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==
+  version "1.0.30001809"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz"
+  integrity sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==
 
 chokidar@^3.3.0, chokidar@^3.5.2:
   version "3.6.0"


### PR DESCRIPTION
Adds snapshots of peripheral records (e.g. site names, linked data) to peripheral versions via the ActiveSnapshot gem, so that changes to associated records appear in the version history alongside changes to the base record itself.

Draft PR; TODO:

- [x] Scaffolding
- [x] Peripheral records of Sites
- [x] Peripheral records of C14s
- [x] Peripheral records of Typos
- [x] Site - Context - Sample - [Chron] ?
- [x] References - Citations - Citable ?
- [x] Rebase on master #501