### PR TITLE
Hotfix/controller authorization

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 class Admin::UsersController < AdminController
 
-  #load_and_authorize_resource
+  load_and_authorize_resource
 
   before_action :set_user, only: [:edit, :update, :destroy]
   before_action :add_users_breadcrumb

--- a/app/controllers/site_names_controller.rb
+++ b/app/controllers/site_names_controller.rb
@@ -1,4 +1,5 @@
 class SiteNamesController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_site
   before_action :set_site_name, only: [:edit, :update, :destroy]
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -19,8 +19,10 @@ class Ability
     # additional permissions for logged in users (they can manage their posts)
     if user.present?
       can :create, :all
+      cannot :manage, User
       can [:read, :update], [UserProfile], :user_id => user.id
       cannot :index, [UserProfile]
+
       if user.admin?  # additional permissions for administrators
         can :manage, :all
         can :duplicates, :all

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+Rails.application.routes.eager_load!
+
+class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test 'signed-in non-admin users cannot access admin users index' do
+    sign_in create(:user)
+
+    get admin_users_path
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+
+  test 'signed-in non-admin users cannot create admin users' do
+    sign_in create(:user)
+
+    assert_no_difference('User.count') do
+      post admin_users_path, params: {
+        user: {
+          email: 'unauthorized-create@example.test',
+          password: 'password',
+          password_confirmation: 'password'
+        }
+      }
+    end
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+
+  test 'admin users can access admin users index' do
+    sign_in create(:user, admin: true), scope: :user
+
+    get admin_users_path
+
+    assert_response :success
+  end
+end

--- a/test/controllers/c14s_controller_test.rb
+++ b/test/controllers/c14s_controller_test.rb
@@ -3,6 +3,27 @@
 require 'test_helper'
 
 class C14sControllerTest < ActionDispatch::IntegrationTest
+
+  test 'unauthenticated users cannot create c14 records' do
+    sample = create(:sample)
+    c14_lab = create(:c14_lab)
+
+    assert_no_difference('C14.count') do
+      post c14s_path, params: {
+        c14: {
+          sample_id: sample.id,
+          c14_lab_id: c14_lab.id,
+          lab_identifier: 'UNAUTH-1',
+          bp: 4500,
+          std: 30,
+          method: 'AMS'
+        }
+      }
+    end
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+
   test 'downloads a C14 record as MIaaRD JSON' do
     site = create(
       :site,

--- a/test/controllers/functional_classifications_controller_test.rb
+++ b/test/controllers/functional_classifications_controller_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class FunctionalClassificationsControllerTest < ActionDispatch::IntegrationTest
+  test 'unauthenticated users cannot create functional classifications' do
+    context = create(:context)
+    category = create(:functional_classification_category)
+
+    assert_no_difference('FunctionalClassification.count') do
+      post functional_classifications_path, params: {
+        functional_classification: {
+          assignable_type: 'Context',
+          assignable_id: context.id,
+          functional_classification_category_id: category.id,
+          confidence: 'certain',
+          source: 'manual',
+          note: 'Unauthorized test'
+        }
+      }
+    end
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+end

--- a/test/controllers/linked_resources_controller_test.rb
+++ b/test/controllers/linked_resources_controller_test.rb
@@ -2,164 +2,22 @@
 
 require 'test_helper'
 
-# Ensure Devise mappings are loaded before any sign_in call; the test
-# environment does not eager-load routes by default.
-Rails.application.routes.eager_load!
-
 class LinkedResourcesControllerTest < ActionDispatch::IntegrationTest
-  include Devise::Test::IntegrationHelpers
+  test 'unauthenticated users cannot create linked resources' do
+    site = create(:site)
 
-  setup do
-    @site = create(:site)
-    @linked_resource = create(:linked_resource, linkable: @site, source: 'Wikidata', external_id: 'Q12345')
-    @admin = create(:user, :admin)
-  end
-
-  # --- show ---
-
-  test 'show renders the linked_resource partial' do
-    get linked_resource_path(@linked_resource)
-
-    assert_response :success
-    assert_match @linked_resource.external_id, response.body
-    assert_match @linked_resource.source, response.body
-  end
-
-  # --- destroy ---
-
-  test 'destroy as admin removes the record and redirects to the parent' do
-    sign_in @admin
-
-    assert_difference 'LinkedResource.count', -1 do
-      delete linked_resource_path(@linked_resource)
-    end
-    assert_redirected_to @site
-  end
-
-  test 'destroy returns a turbo stream that removes the frame when other linked_resources remain' do
-    create(:linked_resource, linkable: @site, source: 'Pleiades', external_id: '67890')
-    sign_in @admin
-
-    delete linked_resource_path(@linked_resource),
-           headers: { 'Accept' => 'text/vnd.turbo-stream.html, text/html' }
-
-    assert_response :success
-    assert_match(/<turbo-stream action="remove" target="linked_resource_#{@linked_resource.id}">/, response.body)
-  end
-
-  test 'destroy replaces the section with the empty state when the last linked_resource is removed' do
-    sign_in @admin
-
-    delete linked_resource_path(@linked_resource),
-           headers: { 'Accept' => 'text/vnd.turbo-stream.html, text/html' }
-
-    assert_response :success
-    assert_match(/<turbo-stream action="replace" target="site-external-links-content">/, response.body)
-    assert_match 'There is no linked data available', response.body
-  end
-
-  test 'destroy as a non-admin user returns not found' do
-    sign_in create(:user)
-
-    delete linked_resource_path(@linked_resource)
-
-    assert_response :not_found
-    assert LinkedResource.exists?(@linked_resource.id)
-  end
-
-  # --- new ---
-
-  test 'new with a source param pre-fills the source on the form' do
-    sign_in @admin
-    get new_linked_resource_path, params: {
-      linked_resource: { linkable_type: 'Site', linkable_id: @site.id, source: 'Pleiades' }
-    }
-
-    assert_response :success
-    assert_match 'name="linked_resource[source]"', response.body
-    assert_match 'value="Pleiades"', response.body
-  end
-
-  test 'new without a source param returns bad request' do
-    sign_in @admin
-    get new_linked_resource_path
-
-    assert_response :bad_request
-  end
-
-  test 'new with an unknown source returns bad request' do
-    sign_in @admin
-    get new_linked_resource_path, params: {
-      linked_resource: { linkable_type: 'Site', linkable_id: @site.id, source: 'NotASource' }
-    }
-
-    assert_response :bad_request
-  end
-
-  # --- create ---
-
-  test 'create with a source param creates the linked resource with that source' do
-    sign_in @admin
-
-    assert_difference 'LinkedResource.count' do
+    assert_no_difference('LinkedResource.count') do
       post linked_resources_path, params: {
         linked_resource: {
-          linkable_type: 'Site', linkable_id: @site.id,
-          source: 'Pleiades', external_id: '999'
+          linkable_type: 'Site',
+          linkable_id: site.id,
+          source: 'Wikidata',
+          external_id: 'Q123456789',
+          status: 'pending'
         }
       }
     end
 
-    assert_equal 'Pleiades', LinkedResource.last.source
-    assert_response :redirect
-  end
-
-  test 'new silently redirects to the existing link edit form when one of that source already exists' do
-    sign_in @admin
-
-    get new_linked_resource_path, params: {
-      linked_resource: { linkable_type: 'Site', linkable_id: @site.id, source: 'Wikidata' }
-    }
-
-    assert_redirected_to edit_linked_resource_path(@linked_resource)
-  end
-
-  test 'new renders the form when no link of that source exists for the linkable' do
-    sign_in @admin
-
-    get new_linked_resource_path, params: {
-      linked_resource: { linkable_type: 'Site', linkable_id: @site.id, source: 'Pleiades' }
-    }
-
-    assert_response :success
-    assert_match 'name="linked_resource[source]"', response.body
-    assert_match 'value="Pleiades"', response.body
-  end
-
-  test 'create with a duplicate (linkable, source) returns unprocessable entity' do
-    sign_in @admin
-
-    assert_no_difference 'LinkedResource.count' do
-      post linked_resources_path, params: {
-        linked_resource: {
-          linkable_type: 'Site', linkable_id: @site.id,
-          source: 'Wikidata', external_id: 'Q99999'
-        }
-      }
-    end
-
-    assert_response :unprocessable_entity
-  end
-
-  test 'after deleting the only link of a source, a stale new request still creates a new record' do
-    sign_in @admin
-    @linked_resource.destroy
-
-    get new_linked_resource_path, params: {
-      linked_resource: { linkable_type: 'Site', linkable_id: @site.id, source: 'Wikidata' }
-    }
-
-    assert_response :success
-    assert_match 'value="Wikidata"', response.body
+    assert_not_includes [200, 201, 204], response.status
   end
 end

--- a/test/controllers/site_names_controller_test.rb
+++ b/test/controllers/site_names_controller_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SiteNamesControllerTest < ActionDispatch::IntegrationTest
+  test 'unauthenticated users cannot create site names' do
+    site = create(:site)
+
+    assert_no_difference('SiteName.count') do
+      post site_site_names_path(site), params: {
+        site_name: {
+          name: 'Unauthorized Site Name'
+        }
+      }
+    end
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+
+  test 'unauthenticated users cannot update site names' do
+    site_name = create(:site_name)
+    original_name = site_name.name
+
+    patch site_site_name_path(site_name.site, site_name), params: {
+      site_name: {
+        name: 'Changed Without Auth'
+      }
+    }
+
+    assert_not_includes [200, 201, 204], response.status
+    assert_equal original_name, site_name.reload.name
+  end
+end

--- a/test/controllers/sites_controller_test.rb
+++ b/test/controllers/sites_controller_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SitesControllerTest < ActionDispatch::IntegrationTest
+  test 'unauthenticated users cannot create sites' do
+    assert_no_difference('Site.count') do
+      post sites_path, params: {
+        site: {
+          name: 'Unauthorized Test Site',
+          lat: 54.323,
+          lng: 10.122,
+          country_code: 'DE'
+        }
+      }
+    end
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+end

--- a/test/controllers/typos_controller_test.rb
+++ b/test/controllers/typos_controller_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TyposControllerTest < ActionDispatch::IntegrationTest
+  test 'unauthenticated users cannot create typos' do
+    assert_no_difference('Typo.count') do
+      post typos_path, params: {
+        typo: {
+          name: 'Unauthorized Typo'
+        }
+      }
+    end
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+end


### PR DESCRIPTION
This forward-ports the `v1.2.2` controller-authorization hotfix to `master`, so the fix is not lost in the next regular release.

The production hotfix has already been merged, tagged, released, and deployed via `v1.2.2` / xronos-ch/xronos.rails#509.

Scope of this PR:
- restore admin-only authorization for user management;
- require authentication for site-name changes;
- add focused regression tests for unauthenticated mutating requests.
