### PR TITLE
Hotfix/v1.2.1 controller authorization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,12 @@
 
 ## 1.2.0.9000 [unreleased]
 
+## 1.2.2
+
+- Security hotfix: tightened authorization for mutating controller actions.
+- Disabled unused exposed `measurement_states` routes.
+- Added focused regression tests for unauthorized create/update requests.
+
 ## 1.2.1
 
 * Fixed pagination in context issue show view

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 class Admin::UsersController < AdminController
 
-  #load_and_authorize_resource
+  load_and_authorize_resource
 
   before_action :set_user, only: [:edit, :update, :destroy]
   before_action :add_users_breadcrumb

--- a/app/controllers/site_names_controller.rb
+++ b/app/controllers/site_names_controller.rb
@@ -1,4 +1,5 @@
 class SiteNamesController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_site
   before_action :set_site_name, only: [:edit, :update, :destroy]
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -19,8 +19,10 @@ class Ability
     # additional permissions for logged in users (they can manage their posts)
     if user.present?
       can :create, :all
+      cannot :manage, User
       can [:read, :update], [UserProfile], :user_id => user.id
       cannot :index, [UserProfile]
+
       if user.admin?  # additional permissions for administrators
         can :manage, :all
         can :duplicates, :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,6 @@ Rails.application.routes.draw do
   resources :materials do
     get 'search', on: :collection
   end
-  resources :measurement_states
   resources :references do
     get 'search', on: :collection
   end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -8,7 +8,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   test 'signed-in non-admin users cannot access admin users index' do
-    sign_in create(:user)
+    sign_in create(:user, email: "non-admin-index-#{SecureRandom.hex(8)}@xronos.test"), scope: :user
 
     get admin_users_path
 
@@ -16,12 +16,12 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'signed-in non-admin users cannot create admin users' do
-    sign_in create(:user)
+    sign_in create(:user, email: "non-admin-create-#{SecureRandom.hex(8)}@xronos.test"), scope: :user
 
     assert_no_difference('User.count') do
       post admin_users_path, params: {
         user: {
-          email: 'unauthorized-create@example.test',
+          email: "unauthorized-create-#{SecureRandom.hex(8)}@xronos.test",
           password: 'password',
           password_confirmation: 'password'
         }
@@ -32,7 +32,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'admin users can access admin users index' do
-    sign_in create(:user, admin: true), scope: :user
+    sign_in create(:user, admin: true, email: "admin-index-#{SecureRandom.hex(8)}@xronos.test"), scope: :user
 
     get admin_users_path
 

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+Rails.application.routes.eager_load!
+
+class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test 'signed-in non-admin users cannot access admin users index' do
+    sign_in create(:user)
+
+    get admin_users_path
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+
+  test 'signed-in non-admin users cannot create admin users' do
+    sign_in create(:user)
+
+    assert_no_difference('User.count') do
+      post admin_users_path, params: {
+        user: {
+          email: 'unauthorized-create@example.test',
+          password: 'password',
+          password_confirmation: 'password'
+        }
+      }
+    end
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+
+  test 'admin users can access admin users index' do
+    sign_in create(:user, admin: true), scope: :user
+
+    get admin_users_path
+
+    assert_response :success
+  end
+end

--- a/test/controllers/c14s_controller_test.rb
+++ b/test/controllers/c14s_controller_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class C14sControllerTest < ActionDispatch::IntegrationTest
+
+  test 'unauthenticated users cannot create c14 records' do
+    sample = create(:sample)
+    c14_lab = create(:c14_lab)
+
+    assert_no_difference('C14.count') do
+      post c14s_path, params: {
+        c14: {
+          sample_id: sample.id,
+          c14_lab_id: c14_lab.id,
+          lab_identifier: 'UNAUTH-1',
+          bp: 4500,
+          std: 30,
+          method: 'AMS'
+        }
+      }
+    end
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+
+  test 'downloads a C14 record as MIaaRD JSON' do
+    site = create(
+      :site,
+      name: 'Test Site',
+      lat: 54.323,
+      lng: 10.122,
+      country_code: 'DE'
+    )
+
+    context = create(
+      :context,
+      name: 'Test Context',
+      site: site
+    )
+
+    taxon = create(
+      :taxon,
+      name: 'Homo sapiens',
+      gbif_id: 2_436_436
+    )
+
+    sample = create(
+      :sample,
+      context: context,
+      taxon: taxon
+    )
+
+    c14 = create(
+      :c14,
+      sample: sample,
+      lab_identifier: 'OxA-12345',
+      bp: 4500,
+      std: 30,
+      method: 'AMS'
+    )
+
+    get c14_path(c14, format: :json, schema: C14::MIAARD::SCHEMA)
+
+    assert_response :success
+    assert_equal 'application/json', response.media_type
+
+    json = JSON.parse(response.body)
+
+    assert_equal 'OxA', json['lab_code']
+    assert_equal '12345', json['lab_id']
+    assert_equal 4500, json['conventional_age']
+    assert_equal 30, json['conventional_age_error']
+    assert_equal 'AMS', json['measurement_method']
+    assert_equal 'gbif:2436436', json['sample_taxon_id']
+  end
+
+  test 'downloads C14 records as a MIaaRD collection' do
+    site = create(:site, name: 'Test Site')
+    context = create(:context, site: site)
+    sample = create(:sample, context: context)
+
+    create(
+      :c14,
+      sample: sample,
+      lab_identifier: 'OxA-12345',
+      bp: 4500,
+      std: 30
+    )
+
+    get c14s_path(format: :json, schema: C14::MIAARD::SCHEMA)
+
+    assert_response :success
+    assert_equal 'application/json', response.media_type
+
+    json = JSON.parse(response.body)
+
+    assert json.key?('entries')
+    assert json['entries'].any?
+    assert_equal 'OxA', json['entries'].first['lab_code']
+  end
+
+  test 'downloads filtered C14 records as a MIaaRD collection' do
+    site = create(:site, name: 'Test Site')
+    context = create(:context, site: site)
+    sample = create(:sample, context: context)
+
+    matching = create(
+      :c14,
+      sample: sample,
+      lab_identifier: 'OxA-12345',
+      bp: 4500,
+      std: 30
+    )
+
+    create(
+      :c14,
+      sample: sample,
+      lab_identifier: 'Beta-67890',
+      bp: 3200,
+      std: 25
+    )
+
+    get c14s_path(
+          format: :json,
+          schema: C14::MIAARD::SCHEMA,
+          c14: { lab_identifier: matching.lab_identifier }
+        )
+
+    assert_response :success
+
+    json = JSON.parse(response.body)
+
+    assert_equal 1, json['entries'].length
+    assert_equal 'OxA', json['entries'].first['lab_code']
+    assert_equal '12345', json['entries'].first['lab_id']
+  end
+end

--- a/test/controllers/c14s_controller_test.rb
+++ b/test/controllers/c14s_controller_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class C14sControllerTest < ActionDispatch::IntegrationTest
-
   test 'unauthenticated users cannot create c14 records' do
     sample = create(:sample)
     c14_lab = create(:c14_lab)
@@ -22,117 +21,5 @@ class C14sControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_not_includes [200, 201, 204], response.status
-  end
-
-  test 'downloads a C14 record as MIaaRD JSON' do
-    site = create(
-      :site,
-      name: 'Test Site',
-      lat: 54.323,
-      lng: 10.122,
-      country_code: 'DE'
-    )
-
-    context = create(
-      :context,
-      name: 'Test Context',
-      site: site
-    )
-
-    taxon = create(
-      :taxon,
-      name: 'Homo sapiens',
-      gbif_id: 2_436_436
-    )
-
-    sample = create(
-      :sample,
-      context: context,
-      taxon: taxon
-    )
-
-    c14 = create(
-      :c14,
-      sample: sample,
-      lab_identifier: 'OxA-12345',
-      bp: 4500,
-      std: 30,
-      method: 'AMS'
-    )
-
-    get c14_path(c14, format: :json, schema: C14::MIAARD::SCHEMA)
-
-    assert_response :success
-    assert_equal 'application/json', response.media_type
-
-    json = JSON.parse(response.body)
-
-    assert_equal 'OxA', json['lab_code']
-    assert_equal '12345', json['lab_id']
-    assert_equal 4500, json['conventional_age']
-    assert_equal 30, json['conventional_age_error']
-    assert_equal 'AMS', json['measurement_method']
-    assert_equal 'gbif:2436436', json['sample_taxon_id']
-  end
-
-  test 'downloads C14 records as a MIaaRD collection' do
-    site = create(:site, name: 'Test Site')
-    context = create(:context, site: site)
-    sample = create(:sample, context: context)
-
-    create(
-      :c14,
-      sample: sample,
-      lab_identifier: 'OxA-12345',
-      bp: 4500,
-      std: 30
-    )
-
-    get c14s_path(format: :json, schema: C14::MIAARD::SCHEMA)
-
-    assert_response :success
-    assert_equal 'application/json', response.media_type
-
-    json = JSON.parse(response.body)
-
-    assert json.key?('entries')
-    assert json['entries'].any?
-    assert_equal 'OxA', json['entries'].first['lab_code']
-  end
-
-  test 'downloads filtered C14 records as a MIaaRD collection' do
-    site = create(:site, name: 'Test Site')
-    context = create(:context, site: site)
-    sample = create(:sample, context: context)
-
-    matching = create(
-      :c14,
-      sample: sample,
-      lab_identifier: 'OxA-12345',
-      bp: 4500,
-      std: 30
-    )
-
-    create(
-      :c14,
-      sample: sample,
-      lab_identifier: 'Beta-67890',
-      bp: 3200,
-      std: 25
-    )
-
-    get c14s_path(
-          format: :json,
-          schema: C14::MIAARD::SCHEMA,
-          c14: { lab_identifier: matching.lab_identifier }
-        )
-
-    assert_response :success
-
-    json = JSON.parse(response.body)
-
-    assert_equal 1, json['entries'].length
-    assert_equal 'OxA', json['entries'].first['lab_code']
-    assert_equal '12345', json['entries'].first['lab_id']
   end
 end

--- a/test/controllers/functional_classifications_controller_test.rb
+++ b/test/controllers/functional_classifications_controller_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class FunctionalClassificationsControllerTest < ActionDispatch::IntegrationTest
+  test 'unauthenticated users cannot create functional classifications' do
+    context = create(:context)
+    category = create(:functional_classification_category)
+
+    assert_no_difference('FunctionalClassification.count') do
+      post functional_classifications_path, params: {
+        functional_classification: {
+          assignable_type: 'Context',
+          assignable_id: context.id,
+          functional_classification_category_id: category.id,
+          confidence: 'certain',
+          source: 'manual',
+          note: 'Unauthorized test'
+        }
+      }
+    end
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+end

--- a/test/controllers/linked_resources_controller_test.rb
+++ b/test/controllers/linked_resources_controller_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LinkedResourcesControllerTest < ActionDispatch::IntegrationTest
+  test 'unauthenticated users cannot create linked resources' do
+    site = create(:site)
+
+    assert_no_difference('LinkedResource.count') do
+      post linked_resources_path, params: {
+        linked_resource: {
+          linkable_type: 'Site',
+          linkable_id: site.id,
+          source: 'Wikidata',
+          external_id: 'Q123456789',
+          status: 'pending'
+        }
+      }
+    end
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+end

--- a/test/controllers/lod_links_controller_test.rb
+++ b/test/controllers/lod_links_controller_test.rb
@@ -2,13 +2,13 @@
 
 require 'test_helper'
 
-class LinkedResourcesControllerTest < ActionDispatch::IntegrationTest
-  test 'unauthenticated users cannot create linked resources' do
+class LodLinksControllerTest < ActionDispatch::IntegrationTest
+  test 'unauthenticated users cannot create LOD links' do
     site = create(:site)
 
-    assert_no_difference('LinkedResource.count') do
-      post linked_resources_path, params: {
-        linked_resource: {
+    assert_no_difference('LODLink.count') do
+      post lod_links_path, params: {
+        lod_link: {
           linkable_type: 'Site',
           linkable_id: site.id,
           source: 'Wikidata',

--- a/test/controllers/lod_links_controller_test.rb
+++ b/test/controllers/lod_links_controller_test.rb
@@ -6,7 +6,7 @@ class LodLinksControllerTest < ActionDispatch::IntegrationTest
   test 'unauthenticated users cannot create LOD links' do
     site = create(:site)
 
-    assert_no_difference('LODLink.count') do
+    assert_no_difference('LodLink.count') do
       post lod_links_path, params: {
         lod_link: {
           linkable_type: 'Site',

--- a/test/controllers/site_names_controller_test.rb
+++ b/test/controllers/site_names_controller_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SiteNamesControllerTest < ActionDispatch::IntegrationTest
+  test 'unauthenticated users cannot create site names' do
+    site = create(:site)
+
+    assert_no_difference('SiteName.count') do
+      post site_site_names_path(site), params: {
+        site_name: {
+          name: 'Unauthorized Site Name'
+        }
+      }
+    end
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+
+  test 'unauthenticated users cannot update site names' do
+    site_name = create(:site_name)
+    original_name = site_name.name
+
+    patch site_site_name_path(site_name.site, site_name), params: {
+      site_name: {
+        name: 'Changed Without Auth'
+      }
+    }
+
+    assert_not_includes [200, 201, 204], response.status
+    assert_equal original_name, site_name.reload.name
+  end
+end

--- a/test/controllers/sites_controller_test.rb
+++ b/test/controllers/sites_controller_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SitesControllerTest < ActionDispatch::IntegrationTest
+  test 'unauthenticated users cannot create sites' do
+    assert_no_difference('Site.count') do
+      post sites_path, params: {
+        site: {
+          name: 'Unauthorized Test Site',
+          lat: 54.323,
+          lng: 10.122,
+          country_code: 'DE'
+        }
+      }
+    end
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+end

--- a/test/controllers/typos_controller_test.rb
+++ b/test/controllers/typos_controller_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TyposControllerTest < ActionDispatch::IntegrationTest
+  test 'unauthenticated users cannot create typos' do
+    assert_no_difference('Typo.count') do
+      post typos_path, params: {
+        typo: {
+          name: 'Unauthorized Typo'
+        }
+      }
+    end
+
+    assert_not_includes [200, 201, 204], response.status
+  end
+end


### PR DESCRIPTION
This is an isolated hotfix branch based on v1.2.1.

It tightens controller authorization for selected mutating actions, disables unused measurement_states routes, adds focused regression coverage, and updates the changelog for v1.2.2.

This deliberately excludes unrelated changes currently on master and does not include the broader controller smoke-test framework from #505.